### PR TITLE
ontbrekende koppen toegevoegd

### DIFF
--- a/src/components/song/SongControl.vue
+++ b/src/components/song/SongControl.vue
@@ -113,15 +113,26 @@ export default {
 }
 
 const labels = [
+  { key: 'intro', color: 'deep-purple' },
+  { key: 'introduction', color: 'deep-purple' },
   { key: 'verse', color: 'blue' },
   { key: 'vers', color: 'blue' },
   { key: 'couplet', color: 'blue' },
+  { key: 'pre-chorus', color: 'purple' },
   { key: 'chorus', color: 'purple' },
   { key: 'refrein', color: 'purple' },
   { key: 'bridge', color: 'green' },
   { key: 'tag', color: 'deep-purple' },
+  { key: 'tussenspel', color: 'deep-purple' },
+  { key: 'interlude', color: 'deep-purple' },
+  { key: 'misc', color: 'deep-purple' },
+  { key: 'ending', color: 'red-10' },
   { key: 'end', color: 'red-10' },
-  { key: 'eind', color: 'red-10' }
+  { key: 'eind', color: 'red-10' },
+  { key: 'slide', color: 'blue' },
+  { key: 'vamp', color: 'blue' },
+  { key: 'other', color: 'blue' },
+  { key: 'scripture', color: 'red-10' }
 ]
 
 function splitSong (text, linesPerSlide) {


### PR DESCRIPTION
Ontbrekende koppen toegevoegd.

Onderstaand "Liedtekst" met alle koppen met kleuren (tbv testen)

```
intro
color: 'deep-purple'

introduction
color: 'deep-purple'

verse
color: 'blue'

vers
color: 'blue'

couplet
color: 'blue'

pre-chorus
color: 'purple'

chorus
color: 'purple'

refrein
color: 'purple'

bridge
color: 'green'

tag
color: 'deep-purple'

tussenspel
color: 'deep-purple'

interlude
color: 'deep-purple'

misc
color: 'deep-purple'

ending
color: 'red-10'

end
color: 'red-10'

eind
color: 'red-10'

slide
color: 'blue'

vamp
color: 'blue'

other
color: 'blue'

scripture
color: 'red-10'
```