### PR TITLE
gelijktijdig scrollen van song & translation

### DIFF
--- a/src/components/song/SongSettings.vue
+++ b/src/components/song/SongSettings.vue
@@ -13,17 +13,19 @@
 
         <div class="row q-gutter-md">
           <div class="col">
-            <q-input v-model="settings.text" outlined label="Tekst" type="textarea" class="input-songtext" />
+            <q-input ref="inputSongRef" v-model="settings.text" outlined label="Tekst" type="textarea" class="input-songtext" @scroll="onScrollSong" />
           </div>
 
           <div class="col">
             <q-input
+              ref="inputTranslateRef"
               v-model="settings.translation"
               outlined
               label="Vertaling"
               type="textarea"
               class="input-songtext"
               :class="{ 'q-field--readonly': !settings.translation }"
+              @scroll="onScrollTranslate"
             >
               <q-btn
                 v-if="!settings.translation"
@@ -65,7 +67,8 @@ export default {
     return {
       tab: 'text',
       isTranslating: false,
-      background: null
+      background: null,
+      ignoreSource: null
     }
   },
   computed: {
@@ -92,6 +95,26 @@ export default {
     resetBackground () {
       this.settings.fileId = null
       this.background = null
+    },
+    scroll (source) {
+      if (this.ignoreSource === source) {
+        this.ignoreSource = null
+        return
+      }
+
+      if (source === 'song') {
+        this.ignoreSource = 'translate'
+        this.$refs.inputTranslateRef.getNativeElement().scrollTop = this.$refs.inputSongRef.getNativeElement().scrollTop
+      } else {
+        this.ignoreSource = 'song'
+        this.$refs.inputSongRef.getNativeElement().scrollTop = this.$refs.inputTranslateRef.getNativeElement().scrollTop
+      }
+    },
+    onScrollSong () {
+      this.scroll('song')
+    },
+    onScrollTranslate () {
+      this.scroll('translate')
     }
   }
 }


### PR DESCRIPTION
nu methode `getNativeElement ()` gebruikt, maar deze verdwijnt een keer.
_Description: DEPRECATED; Access 'nativeEl' directly instead;_ 

vanaf versie 2.10.1+ --> direct te benaderen door `nativeEl` (computedProp)
zie: https://quasar.dev/vue-components/input

Wij gebruiken nu versie ^2.6.0 van quasar zag ik; dus nieuwe manier is nog niet bruikbaar.
weet niet of we de versie omhoog kunnen gooien of dat we beter dit in de toekomst weer kunnen aanpassen.