### PR TITLE
Setlist presentationPresets niet vervangen als reeds bestaad

### DIFF
--- a/src/stores/service.js
+++ b/src/stores/service.js
@@ -67,7 +67,7 @@ export default defineStore('service', {
         })
       }
 
-      presentationPresets.forEach(this.upsertPresentation)
+      presentationPresets.forEach(this.addNoExixtingPresentation)
     },
 
     addPresentation (presentation) {
@@ -83,6 +83,10 @@ export default defineStore('service', {
       existing
         ? this.updatePresentation(existing, presentation.settings)
         : this.addPresentation(presentation)
+    },
+    addNoExixtingPresentation (presentation) {
+      const existing = this.service.presentations.find(p => p.id === presentation.id)
+      if (!existing) { this.addPresentation(presentation) }
     },
     removePresentation (presentation) {
       this.service.presentations = this.service.presentations.filter(s => s.id !== presentation.id)

--- a/src/stores/service.js
+++ b/src/stores/service.js
@@ -34,7 +34,7 @@ export default defineStore('service', {
       }
 
       // Default countdown
-      this.upsertPresentation({
+      this.addOrUpdatePresentation({
         id: 'countdown',
         type: 'countdown',
         settings: {
@@ -45,7 +45,7 @@ export default defineStore('service', {
 
       // Default host caption
       if (host) {
-        this.upsertPresentation({
+        this.addOrUpdatePresentation({
           id: 'host',
           type: 'caption',
           settings: {
@@ -57,7 +57,7 @@ export default defineStore('service', {
 
       // Default preacher caption
       if (preacher) {
-        this.upsertPresentation({
+        this.addOrUpdatePresentation({
           id: 'preacher',
           type: 'caption',
           settings: {
@@ -67,7 +67,7 @@ export default defineStore('service', {
         })
       }
 
-      presentationPresets.forEach(this.addNoExixtingPresentation)
+      presentationPresets.forEach(this.addOrIgnorePresentation)
     },
 
     addPresentation (presentation) {
@@ -77,16 +77,21 @@ export default defineStore('service', {
     updatePresentation (presentation, settings) {
       Object.assign(presentation.settings, settings)
     },
-    upsertPresentation (presentation) {
+    addOrUpdatePresentation (presentation) {
       const existing = this.service.presentations.find(p => p.id === presentation.id)
 
       existing
         ? this.updatePresentation(existing, presentation.settings)
         : this.addPresentation(presentation)
     },
-    addNoExixtingPresentation (presentation) {
+    addOrIgnorePresentation (presentation) {
       const existing = this.service.presentations.find(p => p.id === presentation.id)
-      if (!existing) { this.addPresentation(presentation) }
+
+      if (existing) {
+        return // ignore
+      }
+
+      this.addPresentation(presentation)
     },
     removePresentation (presentation) {
       this.service.presentations = this.service.presentations.filter(s => s.id !== presentation.id)


### PR DESCRIPTION
fix : aangepaste standaard sheet settings werden teruggezet na dat je in de dienst eigenschappen was geweest. Nu alleen toegevoegd wanneer niet bestaat.