### PR TITLE
Dev : Video [start/eind tijd; controller zichtbaar]

### DIFF
--- a/src/components/presentation-types.js
+++ b/src/components/presentation-types.js
@@ -96,7 +96,9 @@ export default [
       title: '',
       fileId: null,
       play: false,
-      time: 0
+      time: 0,
+      startTime: 0,
+      endTime: -1
     },
     components: {
       settings: require('./video/VideoSettings.vue').default,

--- a/src/components/video/VideoControl.vue
+++ b/src/components/video/VideoControl.vue
@@ -54,7 +54,7 @@ export default {
   extends: BaseControl,
   data () {
     return {
-      currentTime: 0,
+      currentTime: null,
       duration: 0,
       readyStateFirst: -1,
       moveSlider: false,
@@ -107,11 +107,13 @@ export default {
   mounted () {
     this.pause()
     this.readyStateFirst = -1
+    if (this.preview) this.settings.time = this.settings.startTime
   },
   methods: {
     togglePlayPause () {
       if (!this.settings.play && this.currentTime >= this.settings.endTime) return
       this.settings.play = !this.settings.play
+      if (!this.settings.play) this.settings.time = this.currentTime
     },
     moveTime (phase) {
       if (phase === 'start') {
@@ -134,27 +136,16 @@ export default {
       this.currentTime = e.target.currentTime
     },
     loadedmetadata (e) {
-      /* e.target.readyState
-        0 = HAVE_NOTHING - no information whether or not the video is ready
-        1 = HAVE_METADATA - metadata for the video is ready
-        .loadedmetadata
-        2 = HAVE_CURRENT_DATA - data for the current playback position is available, but not enough data to play next frame/millisecond
-        .loadeddata
-        3 = HAVE_FUTURE_DATA - data for the current and at least the next frame is available
-        .canplay
-        4 = HAVE_ENOUGH_DATA - enough data available to start playing
-        .canplaythrough
-      */
       if (this.readyStateFirst < 1 && e.target.readyState > 0) {
         // start time
-        if (this.settings.time < this.settings.startTime || 0) {
+        if (this.settings.time < (this.settings.startTime || 0)) {
           this.settings.time = (this.settings.startTime || 0) + 0.0001 * (Math.random() + 0.0001)
-        } else { // altijd ander startpunt dan vorige film om te resetten naar dat punt
+        } else { // always different starting point from previous movie to reset to that point
           this.settings.time += 0.0001 * (Math.random() + 0.0001)
         }
         // end time
         this.duration = e.target.duration
-        if (this.settings.endTime <= this.settings.startTime || 0) this.settings.endTime = this.duration
+        if (this.settings.endTime <= (this.settings.startTime || 0)) this.settings.endTime = this.duration
         // labels slider
         this.markerLabels = [
           { value: this.settings.startTime, label: timeFormat(this.settings.startTime) },
@@ -164,7 +155,6 @@ export default {
       }
     },
     canplaythrough (e) {
-      console.log(`canplaythrough(${e.target.readyState})`)
       if (this.readyStateFirst < 4 && e.target.readyState === 4) {
         if (!this.clear && !this.preview) {
           this.play()

--- a/src/components/video/VideoControl.vue
+++ b/src/components/video/VideoControl.vue
@@ -112,8 +112,12 @@ export default {
   methods: {
     togglePlayPause () {
       if (!this.settings.play && this.currentTime >= this.settings.endTime) return
-      this.settings.play = !this.settings.play
-      if (!this.settings.play) this.settings.time = this.currentTime
+      if (this.settings.play) {
+        this.settings.play = false
+        this.settings.time = this.currentTime
+      } else {
+        this.play()
+      }
     },
     moveTime (phase) {
       if (phase === 'start') {
@@ -127,6 +131,10 @@ export default {
       this.settings.time = this.currentTime
     },
     play () {
+      if (this.player.readyState < 4) {
+        setTimeout(() => this.play(), 50)
+        return
+      }
       this.settings.play = true
     },
     pause () {

--- a/src/components/video/VideoSettings.vue
+++ b/src/components/video/VideoSettings.vue
@@ -8,21 +8,53 @@
       </template>
     </q-file>
 
-    <video
-      v-if="fileUrl"
-      ref="player"
-      :src="fileUrl"
-      controls
-      muted
-      playsinline
-      disablePictureInPicture
-      controlsList="nodownload noremoteplayback noplaybackrate"
-      x-webkit-airplay="deny"
-      class="full-width"
-    />
-    <div class="q-pa-md col">
-      <q-btn color="primary" icon="first_page" label="zet start tijd" @click="setStartTime" /> {{ settings.startTime }}
-      <q-btn color="primary" icon="last_page" label="zet stop (clear) tijd" @click="setEndTime" /> {{ settings.endTime }}
+    <div v-if="fileUrl">
+      <div class="q-pa-md row">
+        <video
+          v-if="fileUrl"
+          ref="player"
+          :src="fileUrl"
+          controls
+          muted
+          playsinline
+          disablePictureInPicture
+          controlsList="nodownload noremoteplayback noplaybackrate"
+          x-webkit-airplay="deny"
+          class="full-width"
+          @timeupdate="timeupdate"
+          @loadedmetadata="loadedmetadata"
+        />
+      </div>
+
+      <div class="q-px-xl q-py-md row">
+        <q-range
+          v-model="range"
+          :min="0"
+          :max="duration"
+          :left-label-value="rangeTimeMinFormat"
+          :right-label-value="rangeTimeMaxFormat"
+          label-always
+          color="secondary"
+          @change="rangeChange"
+        />
+      </div>
+      <div class="q-pa-md row">
+        <div class="col2">
+          <q-btn color="primary" icon="first_page" label="huidig = start positie" class="float-left" dense @click="setStartTime" />
+          <q-btn round color="secondary" icon="play_arrow" class="float-left" dense @click="playStart">
+            <q-tooltip>speel vanaf start positie af</q-tooltip>
+          </q-btn>
+        </div>
+        <div class="col" />
+        <div class="col2">
+          <q-btn color="primary" icon-right="last_page" label="huidig = stop positie" dense class="float-right" @click="setEndTime" />
+          <q-btn round color="secondary" icon="play_arrow" class="float-right" dense @click="playEnd">
+            <q-tooltip>speel laatste 5 sec af</q-tooltip>
+          </q-btn>
+          <br>
+          <q-toggle v-model="endPause" label="Stop op 'stop positie'" left-label class="float-right" />
+        </div>
+      </div>
     </div>
   </q-card-section>
 </template>
@@ -34,27 +66,91 @@ export default {
   extends: BaseSettings,
   data () {
     return {
-      file: null
+      file: null,
+      duration: 0,
+      range: {
+        min: 0,
+        max: this.duration
+      },
+      endPause: false
     }
   },
   computed: {
     fileUrl () {
       return this.$store.getMediaUrl(this.settings.fileId)
+    },
+    rangeTimeMinFormat () {
+      return timeFormat(this.range.min)
+    },
+    rangeTimeMaxFormat () {
+      return timeFormat(this.range.max)
     }
   },
   methods: {
     setStartTime () {
-      this.settings.startTime = this.$refs.player.currentTime
+      if (this.$refs.player.currentTime >= this.range.max) return
+      this.range.min = this.$refs.player.currentTime
+      this.rangeChange()
     },
     setEndTime () {
-      this.settings.endTime = this.$refs.player.currentTime
+      if (this.$refs.player.currentTime <= this.range.min) return
+      this.range.max = this.$refs.player.currentTime
+      this.rangeChange()
     },
     update (file) {
       this.settings.fileId = this.$store.addMedia(file)
       this.settings.title = file.name
       this.settings.setStartTime = 0
-      this.settings.endTime = this.$refs.player.duration
+      this.settings.endTime = -1
+    },
+    rangeChange () {
+      this.settings.startTime = this.range.min
+      this.settings.endTime = this.range.max
+    },
+    timeupdate (e) {
+      if (this.endPause && e.target.currentTime >= this.settings.endTime) e.target.pause()
+    },
+    loadedmetadata (e) {
+      if (e.target.readyState > 0) {
+        // end time
+        this.duration = e.target.duration
+        if (this.settings.endTime <= this.settings.startTime || 0) this.settings.endTime = this.duration
+        // range
+        this.range = {
+          min: this.settings.startTime,
+          max: this.settings.endTime
+        }
+      }
+    },
+    playStart () {
+      this.$refs.player.pause()
+      this.$refs.player.currentTime = this.settings.startTime
+      this.$refs.player.play()
+    },
+    playEnd () {
+      this.$refs.player.pause()
+      this.endPause = true
+      this.$refs.player.currentTime = this.settings.endTime - 5
+      this.$refs.player.play()
     }
   }
 }
+
+function timeFormat (totalSeconds) {
+  if (typeof totalSeconds !== 'number') return ''
+
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = (totalSeconds % 60).toFixed(0).toString().padStart(2, '0')
+
+  if (totalSeconds >= 3600) return `${hours}:${minutes.toString().padStart(2, '0')}:${seconds}`
+
+  return `${minutes}:${seconds}`
+}
 </script>
+
+<style scoped>
+video {
+  height: 40vh
+}
+</style>

--- a/src/components/video/VideoSettings.vue
+++ b/src/components/video/VideoSettings.vue
@@ -37,6 +37,9 @@
           color="secondary"
           @change="rangeChange"
         />
+        <q-badge color="secondary">
+          {{ currentTimeF }}
+        </q-badge>
       </div>
       <div class="q-pa-md row">
         <div class="col2">
@@ -72,7 +75,8 @@ export default {
         min: 0,
         max: this.duration
       },
-      endPause: false
+      endPause: false,
+      currentTime: 0
     }
   },
   computed: {
@@ -84,6 +88,9 @@ export default {
     },
     rangeTimeMaxFormat () {
       return timeFormat(this.range.max)
+    },
+    currentTimeF () {
+      return timeFormat(this.currentTime)
     }
   },
   methods: {
@@ -100,7 +107,8 @@ export default {
     update (file) {
       this.settings.fileId = this.$store.addMedia(file)
       this.settings.title = file.name
-      this.settings.setStartTime = 0
+      this.range.min = 0
+      this.settings.startTime = 0
       this.settings.endTime = -1
     },
     rangeChange () {
@@ -108,13 +116,16 @@ export default {
       this.settings.endTime = this.range.max
     },
     timeupdate (e) {
+      this.currentTime = e.target.currentTime
       if (this.endPause && e.target.currentTime >= this.settings.endTime) e.target.pause()
     },
     loadedmetadata (e) {
       if (e.target.readyState > 0) {
         // end time
         this.duration = e.target.duration
-        if (this.settings.endTime <= this.settings.startTime || 0) this.settings.endTime = this.duration
+        if (this.settings.endTime <= (this.settings.startTime || 0)) this.settings.endTime = this.duration
+        if (this.settings.endTime > this.duration) this.settings.endTime = this.duration
+        if (this.settings.startTime > this.duration) this.settings.startTime = 0
         // range
         this.range = {
           min: this.settings.startTime,

--- a/src/components/video/VideoSettings.vue
+++ b/src/components/video/VideoSettings.vue
@@ -1,15 +1,16 @@
 <template>
   <q-card-section>
+    <q-input v-if="fileUrl" v-model="settings.title" outlined label="Naam" :rules="['required']" class="q-mt-sm" />
+
     <q-file v-model="file" accept="video/*" label="Selecteer video" outlined @update:model-value="update">
       <template #prepend>
         <q-icon name="smart_display" />
       </template>
     </q-file>
 
-    <q-input v-if="fileUrl" v-model="settings.title" outlined label="Naam" :rules="['required']" class="q-mt-sm" />
-
     <video
       v-if="fileUrl"
+      ref="player"
       :src="fileUrl"
       controls
       muted
@@ -19,6 +20,10 @@
       x-webkit-airplay="deny"
       class="full-width"
     />
+    <div class="q-pa-md col">
+      <q-btn color="primary" icon="first_page" label="zet start tijd" @click="setStartTime" /> {{ settings.startTime }}
+      <q-btn color="primary" icon="last_page" label="zet stop (clear) tijd" @click="setEndTime" /> {{ settings.endTime }}
+    </div>
   </q-card-section>
 </template>
 
@@ -38,9 +43,17 @@ export default {
     }
   },
   methods: {
+    setStartTime () {
+      this.settings.startTime = this.$refs.player.currentTime
+    },
+    setEndTime () {
+      this.settings.endTime = this.$refs.player.currentTime
+    },
     update (file) {
       this.settings.fileId = this.$store.addMedia(file)
       this.settings.title = file.name
+      this.settings.setStartTime = 0
+      this.settings.endTime = this.$refs.player.duration
     }
   }
 }


### PR DESCRIPTION
- [x] #16 start en eindtijd van video kunnen opgeven
- [x] #136 Film : Controle balk zichtbaar houden [remaining time]
- [x] Film pas starten nadat voldoende geladen (tegen haperingen begin)
> - [x] nu eerst `readyStade `controle player gebruikt, voor 1e inlading
> - [x] wanneer je verschuift krijg je weer een nieuwe `readyState `4 wanneer canplaythrough, hier ook elke keer op wachten ?
> - [x] Kan hiervoor ook de `readyStade `van de beamer/livestream component worden ingezien ? (maar hoeveel zijn dit, werkelijk, preview, in web-app we/niet aan?) --> voor nu niet toepassen [ waarschijnlijk is de control voldoende check]
- [x] Aan eind naar Pause

add: `startTime `& `endTime `to video settings
