### PR TITLE
fix OutputPreview: short view of scrollbar / no style 

### DIFF
--- a/src/components/output/OutputPreview.vue
+++ b/src/components/output/OutputPreview.vue
@@ -33,11 +33,13 @@ export default {
     }
   },
   created () {
-    this.showDebounce = debounce(this.showDebounce, 100)
+    this.showDebounce = debounce(this.showDebounce, 1)
   },
   mounted () {
     const iframe = this.$refs.iframe.contentDocument
 
+    // remove scrollbars on iframe body & change default electron margin.
+    iframe.body.style.cssText += 'overflow: hidden; margin: 0;'
     // Sync styles
     const styles = document.querySelectorAll('link,style')
     for (const style of styles) {
@@ -51,7 +53,7 @@ export default {
 
     app.mount(iframe.body)
 
-    // delay show ifarme: ivm eerst volledig geladen moet zijn voor weergave, anders zie je scrollbars
+    // delay 1ms show ifarme: ivm eerst css volledig geladen moet zijn voor weergave, anders zie je tekst op verkeerde plek zonder opmaak
     this.showDebounce()
   },
   methods: {

--- a/src/components/output/OutputPreview.vue
+++ b/src/components/output/OutputPreview.vue
@@ -1,12 +1,13 @@
 <template>
   <q-responsive :ratio="$store.outputRatio" class="output-preview" :style="style">
-    <iframe ref="iframe" />
+    <iframe v-show="show" ref="iframe" />
     <img v-if="visualView" :src="require(`../../assets/view${visualView}.png`)" class="overlay">
   </q-responsive>
 </template>
 
 <script>
 import { createApp } from 'vue'
+import { debounce } from 'quasar'
 
 export default {
   props: {
@@ -17,6 +18,11 @@ export default {
     },
     bgStyle: Object
   },
+  data () {
+    return {
+      show: false
+    }
+  },
   computed: {
     style () {
       if (this.bgStyle) return this.bgStyle
@@ -25,6 +31,9 @@ export default {
       style.backgroundBlendMode = 'screen'
       return style
     }
+  },
+  created () {
+    this.showDebounce = debounce(this.showDebounce, 100)
   },
   mounted () {
     const iframe = this.$refs.iframe.contentDocument
@@ -41,6 +50,14 @@ export default {
     app.config.globalProperties.$store = this.$store
 
     app.mount(iframe.body)
+
+    // delay show ifarme: ivm eerst volledig geladen moet zijn voor weergave, anders zie je scrollbars
+    this.showDebounce()
+  },
+  methods: {
+    showDebounce () {
+      this.show = true
+    }
   }
 }
 </script>

--- a/src/components/output/OutputPreview.vue
+++ b/src/components/output/OutputPreview.vue
@@ -53,7 +53,7 @@ export default {
 
     app.mount(iframe.body)
 
-    // delay 1ms show ifarme: ivm eerst css volledig geladen moet zijn voor weergave, anders zie je tekst op verkeerde plek zonder opmaak
+    // delay 1ms show iframe: ivm first css must be fully loaded before display, otherwise you see text in wrong place without formatting
     this.showDebounce()
   },
   methods: {


### PR DESCRIPTION
- [x] by debounce on show
- [x] scrollbar ook met overflow hidden en margin 0 op body iframe
- [x] ook mogelijk op een andere manier? --> debounce nu op 1ms gezet en daar werkt het mee icm moargin en hidden.
(@load , onload e.d. allemaal te vroeg.)