### PR TITLE
song settings invoer naar q editor met label opmaak

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -90,8 +90,8 @@ module.exports = configure(function (ctx) {
       chainWebpack (chain) {
         chain.plugin('eslint-webpack-plugin')
           .use(ESLintPlugin, [{ extensions: ['js', 'vue'] }])
-      },
-      devtool: 'source-map' // remove next line before build
+      } // ,
+      // devtool: 'source-map' // remove line before build
     },
 
     // Full list of options: https://v2.quasar.dev/quasar-cli-webpack/quasar-config-js#Property%3A-devServer

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -90,7 +90,8 @@ module.exports = configure(function (ctx) {
       chainWebpack (chain) {
         chain.plugin('eslint-webpack-plugin')
           .use(ESLintPlugin, [{ extensions: ['js', 'vue'] }])
-      }
+      },
+      devtool: 'source-map'
     },
 
     // Full list of options: https://v2.quasar.dev/quasar-cli-webpack/quasar-config-js#Property%3A-devServer

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -91,7 +91,7 @@ module.exports = configure(function (ctx) {
         chain.plugin('eslint-webpack-plugin')
           .use(ESLintPlugin, [{ extensions: ['js', 'vue'] }])
       },
-      devtool: 'source-map'
+      devtool: 'source-map' // remove next line before build
     },
 
     // Full list of options: https://v2.quasar.dev/quasar-cli-webpack/quasar-config-js#Property%3A-devServer

--- a/src/components/common/Caret.js
+++ b/src/components/common/Caret.js
@@ -1,0 +1,50 @@
+/*
+Get/Set cursor position of contentEditable element with linebreaks
+* https://stackoverflow.com/questions/46434775/accounting-for-brs-in-contenteditable-caret-position
+*/
+
+function pathFromNode (node, reference) {
+  function traverse (node, acc) {
+    if (node === reference) {
+      return acc
+    } else {
+      const parent = node.parentNode
+      const index = [...parent.childNodes].indexOf(node)
+      return traverse(parent, [index, ...acc])
+    }
+  }
+  return traverse(node, [])
+}
+
+function nodeFromPath (path, reference) {
+  if (path.length === 0) {
+    return reference
+  } else {
+    const [index, ...rest] = path
+    const next = reference.childNodes[index]
+    return nodeFromPath(rest, next)
+  }
+}
+
+export function getCaret (el) {
+  const range = document.getSelection().getRangeAt(0)
+  return {
+    start: {
+      container: pathFromNode(range.startContainer, el),
+      offset: range.startOffset
+    },
+    end: {
+      container: pathFromNode(range.endContainer, el),
+      offset: range.endOffset
+    }
+  }
+}
+
+export function setCaret (el, start, end) {
+  const range = document.createRange()
+  range.setStart(nodeFromPath(start.container, el), start.offset)
+  range.setEnd(nodeFromPath(end.container, el), end.offset)
+  const selection = document.getSelection()
+  selection.removeAllRanges()
+  selection.addRange(range)
+}

--- a/src/components/common/Caret.js
+++ b/src/components/common/Caret.js
@@ -1,6 +1,15 @@
 /*
 Get/Set cursor position of contentEditable element with linebreaks
-* https://stackoverflow.com/questions/46434775/accounting-for-brs-in-contenteditable-caret-position
+* Base: https://stackoverflow.com/questions/46434775/accounting-for-brs-in-contenteditable-caret-position
+* Combi with Quasar caret of editor
+* add linechar --> line always start with node <div> (after clean editor)
+* -----------------
+* not used in VezyEditorSong --> commented off.
+* getCaret(el) / setCaret(el, start, end) --> Use index of node + char offset last node
+* -----------------
+* used:
+* getCaretLine(el) / setCaretLine(el, start, end) --> Use index of first node + total char offset of that node [calculate between child nodes]
+* -----------------
 */
 
 function pathFromNode (node, reference) {
@@ -16,6 +25,8 @@ function pathFromNode (node, reference) {
   return traverse(node, [])
 }
 
+// not used in VezyEditorSong via setCaret
+/*
 function nodeFromPath (path, reference) {
   if (path.length === 0) {
     return reference
@@ -25,26 +36,167 @@ function nodeFromPath (path, reference) {
     return nodeFromPath(rest, next)
   }
 }
+*/
 
+// not used in VezyEditorSong
+/*
 export function getCaret (el) {
-  const range = document.getSelection().getRangeAt(0)
-  return {
-    start: {
-      container: pathFromNode(range.startContainer, el),
-      offset: range.startOffset
-    },
-    end: {
-      container: pathFromNode(range.endContainer, el),
-      offset: range.endOffset
+  if (el) {
+    const selection = document.getSelection()
+    // only when the selection in element
+    if (isChildOf(selection.anchorNode, el, true) && isChildOf(selection.focusNode, el, true)) {
+      const range = document.getSelection().getRangeAt(0)
+      return {
+        start: {
+          container: pathFromNode(range.startContainer, el),
+          offset: range.startOffset
+        },
+        end: {
+          container: pathFromNode(range.endContainer, el),
+          offset: range.endOffset
+        }
+      }
     }
+  }
+  return null
+}
+*/
+
+// not used in VezyEditorSong
+/*
+export function setCaret (el, start, end) {
+  if (el) {
+    const range = document.createRange()
+    range.setStart(nodeFromPath(start.container, el), start.offset)
+    range.setEnd(nodeFromPath(end.container, el), end.offset)
+    const selection = document.getSelection()
+    selection.removeAllRanges()
+    selection.addRange(range)
+  }
+}
+*/
+
+// Quasar Caret copy
+function isChildOf (el, parent, orSame) {
+  return !el || el === document.body
+    ? false
+    : (orSame === true && el === parent) || (parent === document ? document.body : parent).contains(el.parentNode)
+}
+
+// Quasar Caret copy
+function createRange (node, chars, range) {
+  if (!range) {
+    range = document.createRange()
+    range.selectNode(node)
+    range.setStart(node, 0)
+  }
+  if (chars.count === 0) {
+    range.setEnd(node, 0)
+  } else if (chars.count > 0) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      if (node.textContent.length < chars.count) {
+        chars.count -= node.textContent.length
+      } else {
+        range.setEnd(node, chars.count)
+        chars.count = 0
+      }
+    } else {
+      for (let lp = 0; chars.count !== 0 && lp < node.childNodes.length; lp++) {
+        range = createRange(node.childNodes[lp], chars, range)
+      }
+    }
+  }
+
+  return range
+}
+
+function lineOffsetFirstNode (path, reference, selection, start) {
+  if (path.length === 0) {
+    return 0
+  } else {
+    const lineReference = reference.childNodes[path[0]]
+    let charCount = -1 // offset
+    let node
+    const parentEl = lineReference.parentNode
+    // Detect if selection is backwards
+    const range = document.createRange()
+    range.setStart(selection.anchorNode, selection.anchorOffset) // if after setEnd --> setEnd is used --> range.collapsed = true
+    range.setEnd(selection.focusNode, selection.focusOffset)
+    const direction = range.collapsed ? !start : start // rotate start if backwards
+    range.detach()
+    // count offset node
+    if (direction) {
+      if (selection.anchorNode && isChildOf(selection.anchorNode, parentEl)) {
+        node = selection.anchorNode
+        charCount = selection.anchorOffset
+      }
+    } else {
+      if (selection.focusNode && isChildOf(selection.focusNode, parentEl)) {
+        node = selection.focusNode
+        charCount = selection.focusOffset
+      }
+    }
+    // count nodes before
+    if (charCount > -1) {
+      while (node && node !== parentEl) {
+        if (node !== lineReference && node.previousSibling) {
+          node = node.previousSibling
+          charCount += node.textContent.length
+        } else {
+          node = node.parentNode
+        }
+      }
+    }
+    // return:
+    // = -1 => error/not found
+    // > -1 => offset
+    return charCount
   }
 }
 
-export function setCaret (el, start, end) {
-  const range = document.createRange()
-  range.setStart(nodeFromPath(start.container, el), start.offset)
-  range.setEnd(nodeFromPath(end.container, el), end.offset)
-  const selection = document.getSelection()
-  selection.removeAllRanges()
-  selection.addRange(range)
+function RangeEndFromFirstNodeLineOffset (path, reference, lineOffset) {
+  if (path.length === 0) {
+    return -1
+  } else {
+    const nextReference = reference.childNodes[path[0]]
+    return createRange(nextReference, { count: lineOffset })
+  }
+}
+
+export function getCaretLine (el) {
+  if (el) {
+    const selection = document.getSelection()
+    // only when the selection in element
+    if (isChildOf(selection.anchorNode, el, true) && isChildOf(selection.focusNode, el, true)) {
+      const range = selection.getRangeAt(0)
+      const startContainer = pathFromNode(range.startContainer, el)
+      const endContainer = range.collapsed ? startContainer : pathFromNode(range.endContainer, el)
+      return {
+        start: {
+          container: startContainer,
+          lineOffset: lineOffsetFirstNode(startContainer, el, selection, true)
+        },
+        end: {
+          container: endContainer,
+          lineOffset: lineOffsetFirstNode(endContainer, el, selection, false)
+        }
+      }
+    }
+  }
+  return null
+}
+
+export function setCaretLine (el, start, end) {
+  if (el) {
+    const range = RangeEndFromFirstNodeLineOffset(end.container, el, end.lineOffset)
+    if (start.container === end.container && start.lineOffset === end.lineOffset) {
+      range.setStart(range.endContainer, range.endOffset)
+    } else {
+      const startRange = RangeEndFromFirstNodeLineOffset(start.container, el, start.lineOffset)
+      range.setStart(startRange.endContainer, startRange.endOffset)
+    }
+    const selection = document.getSelection()
+    selection.removeAllRanges()
+    selection.addRange(range)
+  }
 }

--- a/src/components/common/CleanText.js
+++ b/src/components/common/CleanText.js
@@ -4,7 +4,7 @@ export function CleanText (content) {
   // <\/?([briuspmal]*?)>)*? = <br> || </b> || </i> || </u> || </sup> || </small> || <b> || <i> || <u> || <sup> || <small>
   let text = content
     .replace(/<\/?span(.*?)>/gi, '') //    verwijder alle <span ...> & </span> elementen
-    .replace(/ style="(.*?);*">/gi, '>') // verwijder alle extra "style" elementen
+    .replace(/( style="(.*?);*"| class="(.*?)")>/gi, '>') // verwijder alle extra "style" & class elementen
     .replace(/(\r*\n)|(\r(?!\n))|(\v)/g, '<br>') // (Carriage Return[CR] en/of) Linefeed [LF] (alinea-eind) of [CR] of vertical tab [VT] (nieuwe regel), soms door plakken/drag-drop.
     .replace(/(?<!&nbsp;| )&nbsp;(?!&nbsp;| )/g, ' ').replace(/(?<=>) (?=<)/g, '&nbsp;') //                       losse spaties als ' ' plaatsen, tenzij tussen <div> </div>
     .replace(/([^>])((<\/?([briuspmal]*?)>)*?)<br>((<\/([biuspmal]*?)>)*?)<\/div><div>/g, '$1$2$5</div><div>') // drag-drop to empy line, remove <br>

--- a/src/components/common/VezyEditorSong.vue
+++ b/src/components/common/VezyEditorSong.vue
@@ -1,0 +1,138 @@
+<template>
+  <q-editor
+    ref="editor"
+    v-model="content"
+    :definitions="{
+      numberUp: {
+        tip: 'Alle nummers naar superscript plaatsen',
+        label: 'Nummers',
+        handler: numberSup
+      },
+      restore: {
+        tip: 'herstel vorige stand',
+        icon: 'settings_backup_restore',
+        handler: undochange
+      }
+    }"
+    :min-height="minHeight"
+    :toolbar="[['bold', 'italic', 'underline', 'superscript'],['removeFormat', 'numberUp', 'restore']]"
+    class="q-mb-md"
+    @paste.prevent.stop="pastePlainText"
+    @dragstart="backup"
+    @dragend="cleanText"
+    @update:model-value="update"
+    @click="getPosition"
+    @keyup="getPositionArrowKeys"
+    @touchend="getPosition"
+  />
+</template>
+
+<script>
+import { CleanText } from './CleanText.js'
+import { debounce } from 'quasar'
+
+export default {
+  props: {
+    modelValue: {
+      type: String,
+      required: true
+    },
+    savedPos: Number,
+    minHeight: String
+  },
+  emits: [
+    'update:modelValue',
+    'update:savedPos'
+  ],
+  data () {
+    return {
+      content: '',
+      lastEmit: '',
+      contentBackup: ''
+    }
+  },
+  watch: {
+    'modelValue' (val) {
+      if (this.lastEmit !== val) {
+        this.lastEmit = val
+        this.content = val
+      }
+    },
+    'content' (val) {
+      if (this.lastEmit !== val) this.update()
+    }
+  },
+  mounted () {
+    this.content = this.modelValue
+    this.cleanText()
+    this.backup()
+  },
+  created () {
+    this.cleanTextDebounce = debounce(this.cleanTextDebounce, 500)
+  },
+  methods: {
+    update () {
+      this.lastEmit = this.content
+      this.$emit('update:modelValue', this.content)
+      this.getPosition()
+      this.cleanTextDebounce()
+    },
+    pastePlainText (e) {
+      this.backup()
+      const text = e.clipboardData.getData('text/plain')
+      this.$refs.editor.runCmd('insertText', text.replace(/(\r*\n)|(\r(?!\n))|(\v)/g, '\n')) // set all line breaks to \n [LF], due to proper convert to <br> and </div><div>
+      // [CR][LF] = \r\n  |  [LF] = \n  |  [CR] = \r  |  [VT] = \v  (Carriage Return, Line Feed, Vertical Tab)
+      this.content = this.content.replace(/ {2}/g, '&nbsp;&nbsp;') // dubbele SPATIE vervangen
+      this.cleanText()
+    },
+    cleanText () {
+      this.content = CleanText(this.content)
+    },
+    cleanTextDebounce () {
+      this.cleanText()
+    },
+    numberSup () {
+      this.backup()
+      const contents = this.content.split('<sup>')
+      let result = contents[0].replace(/(\d\w|\d)/g, '<sup>$1</sup>')
+      for (let i = 1; i < contents.length; i++) {
+        const supNormal = contents[i].split('</sup>')
+        if (supNormal.length === 1) {
+          result += '<sup>' + supNormal[0]
+        } else {
+          result += '<sup>' + supNormal[0] + '</sup>'
+          for (let j = 1; j < supNormal.length; j++) {
+            result += supNormal[j].replace(/(\d\w|\d)/g, '<sup>$1</sup>')
+          }
+        }
+      }
+      this.content = result
+    },
+    backup () {
+      this.contentBackup = this.content
+    },
+    undochange () {
+      const b = this.content
+      this.content = this.contentBackup
+      this.contentBackup = b
+    },
+    getPositionArrowKeys (e) {
+      switch (e.keyCode) {
+        case 33: // page-up
+        case 34: // page-down
+        case 37: // arrowleft
+        case 38: // arrowup
+        case 39: // arrowright
+        case 40: // arrowdown
+          this.getPosition()
+          break
+        default:
+      }
+    },
+    getPosition () {
+      this.$refs.editor.caret.savePosition()
+      this.$emit('update:savedPos', this.$refs.editor.caret.savedPos)
+    }
+  }
+}
+</script>

--- a/src/components/common/VezyEditorSong.vue
+++ b/src/components/common/VezyEditorSong.vue
@@ -3,11 +3,6 @@
     ref="editor"
     v-model="content"
     :definitions="{
-      numberUp: {
-        tip: 'Alle nummers naar superscript plaatsen',
-        label: 'Nummers',
-        handler: numberSup
-      },
       restore: {
         tip: 'herstel vorige stand',
         icon: 'settings_backup_restore',
@@ -15,29 +10,27 @@
       }
     }"
     :min-height="minHeight"
-    :toolbar="[['bold', 'italic', 'underline', 'superscript'],['removeFormat', 'numberUp', 'restore']]"
+    :toolbar="[['restore']]"
     class="q-mb-md"
     @paste.prevent.stop="pastePlainText"
     @dragstart="backup"
     @dragend="cleanText"
     @update:model-value="update"
-    @click="getPosition"
-    @keyup="getPositionArrowKeys"
-    @touchend="getPosition"
   />
 </template>
 
 <script>
 import { CleanText } from './CleanText.js'
 import { debounce } from 'quasar'
+import { splitSong } from '../song/SongControl.vue'
 
 export default {
   props: {
     modelValue: {
       type: String,
-      required: true
+      required: true,
+      default: ''
     },
-    savedPos: Number,
     minHeight: String
   },
   emits: [
@@ -47,34 +40,34 @@ export default {
   data () {
     return {
       content: '',
-      lastEmit: '',
+      lastEmitText: '',
+      lastEmitHtml: '',
       contentBackup: ''
     }
   },
   watch: {
     'modelValue' (val) {
-      if (this.lastEmit !== val) {
-        this.lastEmit = val
-        this.content = val
+      if (this.lastEmitText !== val) {
+        this.lastEmitText = val
+        this.content = this.textToHtml(val)
       }
     },
     'content' (val) {
-      if (this.lastEmit !== val) this.update()
+      if (this.lastEmitHtml !== val) this.update()
     }
   },
   mounted () {
-    this.content = this.modelValue
-    this.cleanText()
+    this.content = this.textToHtml(this.modelValue)
     this.backup()
   },
   created () {
-    this.cleanTextDebounce = debounce(this.cleanTextDebounce, 500)
+    this.cleanTextDebounce = debounce(this.cleanTextDebounce, 1000)
   },
   methods: {
     update () {
-      this.lastEmit = this.content
-      this.$emit('update:modelValue', this.content)
-      this.getPosition()
+      this.lastEmitHtml = this.content
+      this.lastEmitText = this.HtmlToText(CleanText(this.content))
+      this.$emit('update:modelValue', this.lastEmitText)
       this.cleanTextDebounce()
     },
     pastePlainText (e) {
@@ -86,27 +79,10 @@ export default {
       this.cleanText()
     },
     cleanText () {
-      this.content = CleanText(this.content)
+      this.content = this.textToHtml(this.HtmlToText(CleanText(this.content)))
     },
     cleanTextDebounce () {
       this.cleanText()
-    },
-    numberSup () {
-      this.backup()
-      const contents = this.content.split('<sup>')
-      let result = contents[0].replace(/(\d\w|\d)/g, '<sup>$1</sup>')
-      for (let i = 1; i < contents.length; i++) {
-        const supNormal = contents[i].split('</sup>')
-        if (supNormal.length === 1) {
-          result += '<sup>' + supNormal[0]
-        } else {
-          result += '<sup>' + supNormal[0] + '</sup>'
-          for (let j = 1; j < supNormal.length; j++) {
-            result += supNormal[j].replace(/(\d\w|\d)/g, '<sup>$1</sup>')
-          }
-        }
-      }
-      this.content = result
     },
     backup () {
       this.contentBackup = this.content
@@ -116,22 +92,32 @@ export default {
       this.content = this.contentBackup
       this.contentBackup = b
     },
-    getPositionArrowKeys (e) {
-      switch (e.keyCode) {
-        case 33: // page-up
-        case 34: // page-down
-        case 37: // arrowleft
-        case 38: // arrowup
-        case 39: // arrowright
-        case 40: // arrowdown
-          this.getPosition()
-          break
-        default:
-      }
+    HtmlToText (htmlText) {
+      // first run cleantext in editor
+      return htmlText
+        .replace(/(<\/?b>)|(<\/?i>)|(<\/?u>)|(<\/?sup>)|(<\/?small>)*?/g, '') // verwijder alle opmaak elementen
+        .replace(/^(<div><br><\/div>|<div>)/g, '') // verwijder 1e nieuwe regel of 1e regelstart
+        .replace(/<div><br><\/div>/g, '\n') // vervang lege regel door newline
+        .replace(/<div>/g, '\n') // vervang regelstart door newline
+        .replace(/<\/div>/g, '') // verwijder overige </div>
     },
-    getPosition () {
-      this.$refs.editor.caret.savePosition()
-      this.$emit('update:savedPos', this.$refs.editor.caret.savedPos)
+    textToHtml (text) {
+      const sections = splitSong(text, 100, 0) // no auto split due to extra empty lines to be added
+      let htmlText = ''
+      for (const section of sections) { // beamer split
+        if (section.label) {
+          htmlText += `<div class="section-label text-white bg-${section.label.color}">${section.label.value}</div>`
+        }
+        for (const slide of section.slides) { // livestream split
+          for (const line of slide) { // lines
+            htmlText += line.length ? `<div>${line}</div>` : '<div><br></div>'
+          }
+        }
+        htmlText += '<div class="bg-grey-3" style="font-size: 0.7em;"><br></div>' // empty line
+      }
+      htmlText = htmlText.replace(/<div class="bg-grey-3" style="font-size: 0.7em;"><br><\/div>$/g, '') // remove last section new line
+      if (!htmlText) return ''
+      return htmlText
     }
   }
 }

--- a/src/components/common/VezyEditorSong.vue
+++ b/src/components/common/VezyEditorSong.vue
@@ -7,6 +7,7 @@
     :toolbar="[]"
     content-class="scroll-y"
     class="q-mb-md"
+    :class="borderReadOnlyClass"
     @paste.prevent.stop="pastePlainText"
     @dragstart="backup"
     @dragend="cleanText"
@@ -44,6 +45,10 @@ export default {
     id: {
       type: String,
       default: 'editor'
+    },
+    borderReadOnly: {
+      type: Boolean,
+      default: false
     }
   },
   emits: [
@@ -60,6 +65,9 @@ export default {
     }
   },
   computed: {
+    borderReadOnlyClass () {
+      return this.borderReadOnly ? 'borderReadOnly' : ''
+    },
     labels () {
       return labels
     },
@@ -189,3 +197,9 @@ export default {
   }
 }
 </script>
+
+<style scoped lang="scss">
+.borderReadOnly {
+  border-style: dashed;
+}
+</style>

--- a/src/components/common/VezyEditorSong.vue
+++ b/src/components/common/VezyEditorSong.vue
@@ -131,6 +131,8 @@ export default {
         .replace(/<div class="bg-grey-3" style="font-size: 0.7em;"><br><\/div>$/g, '') // remove last section new line
         .replace(/ {2}/g, '&nbsp;&nbsp;') // replace dubble space with code otherwise it will not be displayed in editor
         .replace(/ <\/div>/g, '&nbsp;</div>') // replace end space with code otherwise it will not be displayed in editor
+        // do not use color end space now; first update caret.js toe use parent/child node change add/remove whith cound offset en startnode.
+        // .replace(/((&nbsp;)+)<\/div>/g, '<span class="bg-grey-4">$1</span></div>') // color bg end space(s)
       if (!htmlText) return ''
       return htmlText
     }

--- a/src/components/common/VezyEditorSong.vue
+++ b/src/components/common/VezyEditorSong.vue
@@ -23,6 +23,7 @@
 import { CleanText } from './CleanText.js'
 import { debounce } from 'quasar'
 import { splitSong } from '../song/SongControl.vue'
+import { getCaret, setCaret } from './Caret.js'
 
 export default {
   props: {
@@ -77,9 +78,14 @@ export default {
       this.cleanText()
     },
     cleanText () {
+      const cursorPosition = getCaret(this.$refs.editor.getContentEl())
       this.lastEmitText = this.HtmlToText(CleanText(this.content))
       this.$emit('update:modelValue', this.lastEmitText)
       this.content = this.textToHtml(this.lastEmitText)
+      // nexttick ivm caret without newline position of q-editor
+      this.$nextTick(() => {
+        setCaret(this.$refs.editor.getContentEl(), cursorPosition.start, cursorPosition.end)
+      })
     },
     cleanTextDebounce () {
       this.cleanText()

--- a/src/components/common/VezyEditorSong.vue
+++ b/src/components/common/VezyEditorSong.vue
@@ -1,5 +1,6 @@
 <template>
   <q-editor
+    :id="id"
     ref="editor"
     v-model="content"
     :height="height"
@@ -10,14 +11,25 @@
     @dragstart="backup"
     @dragend="cleanText"
     @update:model-value="updateContent"
+    @click.right="savePosition"
   />
+  <q-menu context-menu :target="`#${id}`">
+    <q-list dense>
+      <q-item v-for="label, index of labels" :key="index" v-close-popup clickable @click="insertLabel(label.key)">
+        <q-item-section>
+          <q-item-label>{{ label.key }}</q-item-label>
+        </q-item-section>
+      </q-item>
+    </q-list>
+  </q-menu>
 </template>
 
 <script>
 import { CleanText } from './CleanText.js'
 import { debounce, scroll } from 'quasar'
 import { splitSong } from '../song/SongControl.vue'
-import { getCaret, setCaret } from './Caret.js'
+import { getCaretLine, setCaretLine } from './Caret.js'
+import labels from '../song/labels.js'
 const { getScrollTarget, getVerticalScrollPosition, setVerticalScrollPosition } = scroll
 
 export default {
@@ -28,7 +40,11 @@ export default {
       default: ''
     },
     height: String,
-    modelBackup: String
+    modelBackup: String,
+    id: {
+      type: String,
+      default: 'editor'
+    }
   },
   emits: [
     'update:modelValue',
@@ -39,10 +55,14 @@ export default {
       content: '',
       lastEmitText: '',
       lastEmitHtml: '',
-      contentBackup: ''
+      contentBackup: '',
+      savedPosition: null
     }
   },
   computed: {
+    labels () {
+      return labels
+    },
     scrollEl () {
       // give content class - editor: "scroll" or "scroll-y" to find correct one
       return getScrollTarget(this.$refs.editor.getContentEl())
@@ -67,6 +87,9 @@ export default {
     this.cleanTextDebounce = debounce(this.cleanTextDebounce, 500)
   },
   methods: {
+    savePosition () {
+      this.savedPosition = getCaretLine(this.$refs.editor.getContentEl())
+    },
     getScrollPosition () {
       return getVerticalScrollPosition(this.scrollEl) // returns a Number (pixels)
     },
@@ -82,21 +105,19 @@ export default {
       const text = e.clipboardData.getData('text/plain')
       this.$refs.editor.runCmd('insertText', text.replace(/(\r*\n)|(\r(?!\n))|(\v)/g, '\n')) // set all line breaks to \n [LF], due to proper convert to <br> and </div><div>
       // [CR][LF] = \r\n  |  [LF] = \n  |  [CR] = \r  |  [VT] = \v  (Carriage Return, Line Feed, Vertical Tab)
-      this.content = this.content.replace(/ {2}/g, '&nbsp;&nbsp;') // dubbele SPATIE vervangen
+      // gebeurt bij text to html via clean text
+      // this.content = this.content.replace(/ {2}/g, '&nbsp;&nbsp;') // dubbele SPATIE vervangen
       this.cleanText()
     },
     cleanText () {
-      // save q-editor cusor position (without new line) | saved in: this.$refs.editor.caret.savedPos
-      this.$refs.editor.caret.savePosition()
-      // only if active edit (had cursor selection) get/set caret position
-      const cursorPosition = (this.$refs.editor.caret.savedPos > -1) ? getCaret(this.$refs.editor.getContentEl()) : false
+      const cursorPosition = getCaretLine(this.$refs.editor.getContentEl())
       this.lastEmitText = this.htmlToText(CleanText(this.content))
       this.$emit('update:modelValue', this.lastEmitText)
       this.content = this.textToHtml(this.lastEmitText)
       if (cursorPosition) {
         // nexttick ivm caret without newline position of q-editor
         this.$nextTick(() => {
-          setCaret(this.$refs.editor.getContentEl(), cursorPosition.start, cursorPosition.end)
+          setCaretLine(this.$refs.editor.getContentEl(), cursorPosition.start, cursorPosition.end)
         })
       }
     },
@@ -135,10 +156,35 @@ export default {
         .replace(/<div class="bg-grey-3" style="font-size: 0.7em;"><br><\/div>$/g, '') // remove last section new line
         .replace(/ {2}/g, '&nbsp;&nbsp;') // replace dubble space with code otherwise it will not be displayed in editor
         .replace(/ <\/div>/g, '&nbsp;</div>') // replace end space with code otherwise it will not be displayed in editor
-        // do not use color end space now; first update caret.js toe use parent/child node change add/remove whith cound offset en startnode.
-        // .replace(/((&nbsp;)+)<\/div>/g, '<span class="bg-grey-4">$1</span></div>') // color bg end space(s)
+        .replace(/<div> /g, '<div>&nbsp;') // replace start space with code otherwise it will not be displayed in editor
+        .replace(/((&nbsp;)+)<\/div>/g, '<span class="bg-grey-4">$1</span></div>') // color bg end space(s)
+        .replace(/<div>((&nbsp;)+)/g, '<div><span class="bg-grey-4">$1</span>') // color bg start space(s)
       if (!htmlText) return ''
       return htmlText
+    },
+    insertLabel (textLabel) {
+      this.backup()
+      const cursorPosition = this.savedPosition
+      const line = cursorPosition?.start.container[0] || 0
+      const lines = this.htmlToText(CleanText(this.content)).replace(/\r?\n/g, '<br>').split('<br>')
+      let insertLine = 0
+      // search 1st empty line above text lines
+      for (let lineNr = Math.min(line, lines.length - 1); lineNr >= 0; lineNr--) {
+        if (lines[lineNr].length === 0) {
+          insertLine = lineNr + 1
+          break
+        }
+      }
+      lines.splice(insertLine, 0, textLabel)
+      this.lastEmitText = lines.join('\n')
+      this.$emit('update:modelValue', this.lastEmitText)
+      this.content = this.textToHtml(this.lastEmitText)
+      if (cursorPosition) {
+        // nexttick ivm caret without newline position of q-editor
+        this.$nextTick(() => {
+          setCaretLine(this.$refs.editor.getContentEl(), cursorPosition.start, cursorPosition.end)
+        })
+      }
     }
   }
 }

--- a/src/components/common/VezyEditorSong.vue
+++ b/src/components/common/VezyEditorSong.vue
@@ -13,6 +13,7 @@
     @dragend="cleanText"
     @update:model-value="updateContent"
     @click.right="savePosition"
+    @scroll="$emit('scroll')"
   />
   <q-menu context-menu :target="`#${id}`">
     <q-list dense>
@@ -53,7 +54,7 @@ export default {
   },
   emits: [
     'update:modelValue',
-    'update:modelBackup'
+    'update:modelBackup', 'scroll'
   ],
   data () {
     return {

--- a/src/components/common/VezyEditorSong.vue
+++ b/src/components/common/VezyEditorSong.vue
@@ -15,7 +15,7 @@
     @paste.prevent.stop="pastePlainText"
     @dragstart="backup"
     @dragend="cleanText"
-    @update:model-value="update"
+    @update:model-value="updateContent"
   />
 </template>
 
@@ -53,7 +53,7 @@ export default {
       }
     },
     'content' (val) {
-      if (this.lastEmitHtml !== val) this.update()
+      if (this.lastEmitHtml !== val) this.updateContent()
     }
   },
   mounted () {
@@ -61,13 +61,11 @@ export default {
     this.backup()
   },
   created () {
-    this.cleanTextDebounce = debounce(this.cleanTextDebounce, 1000)
+    this.cleanTextDebounce = debounce(this.cleanTextDebounce, 500)
   },
   methods: {
-    update () {
+    updateContent () {
       this.lastEmitHtml = this.content
-      this.lastEmitText = this.HtmlToText(CleanText(this.content))
-      this.$emit('update:modelValue', this.lastEmitText)
       this.cleanTextDebounce()
     },
     pastePlainText (e) {
@@ -79,7 +77,9 @@ export default {
       this.cleanText()
     },
     cleanText () {
-      this.content = this.textToHtml(this.HtmlToText(CleanText(this.content)))
+      this.lastEmitText = this.HtmlToText(CleanText(this.content))
+      this.$emit('update:modelValue', this.lastEmitText)
+      this.content = this.textToHtml(this.lastEmitText)
     },
     cleanTextDebounce () {
       this.cleanText()
@@ -102,7 +102,7 @@ export default {
         .replace(/<\/div>/g, '') // verwijder overige </div>
     },
     textToHtml (text) {
-      const sections = splitSong(text, 100, 0) // no auto split due to extra empty lines to be added
+      const sections = splitSong(text, 100, 0, false) // no auto split due to extra empty lines to be added
       let htmlText = ''
       for (const section of sections) { // beamer split
         if (section.label) {

--- a/src/components/common/VezyEditorSong.vue
+++ b/src/components/common/VezyEditorSong.vue
@@ -81,7 +81,7 @@ export default {
       const cursorPosition = getCaret(this.$refs.editor.getContentEl())
       this.lastEmitText = this.HtmlToText(CleanText(this.content))
       this.$emit('update:modelValue', this.lastEmitText)
-      this.content = this.textToHtml(this.lastEmitText)
+      this.content = this.textToHtml(this.lastEmitText).replace(/ <\/div>/g, '&nbsp;</div>') // replace end space with code otherwise it will not be displayed in editor
       // nexttick ivm caret without newline position of q-editor
       this.$nextTick(() => {
         setCaret(this.$refs.editor.getContentEl(), cursorPosition.start, cursorPosition.end)

--- a/src/components/common/VezyEditorSong.vue
+++ b/src/components/common/VezyEditorSong.vue
@@ -189,9 +189,12 @@ export default {
       this.$emit('update:modelValue', this.lastEmitText)
       this.content = this.textToHtml(this.lastEmitText)
       if (cursorPosition) {
+        // set on label line
+        cursorPosition.start.container = [insertLine + 1, 0]
+        cursorPosition.start.lineOffset = 0
         // nexttick ivm caret without newline position of q-editor
         this.$nextTick(() => {
-          setCaretLine(this.$refs.editor.getContentEl(), cursorPosition.start, cursorPosition.end)
+          setCaretLine(this.$refs.editor.getContentEl(), cursorPosition.start, cursorPosition.start)
         })
       }
     }

--- a/src/components/song/SongControl.vue
+++ b/src/components/song/SongControl.vue
@@ -30,7 +30,7 @@ export default {
   }
 }
 
-export function splitSong (text, linesPerSlideLivestream, linesPerSlideBeamer = 0) {
+export function splitSong (text, linesPerSlideLivestream, linesPerSlideBeamer = 0, minOneSlide = true) {
   if (!text) return []
 
   return splitSongMaxLines(text.replace(/\r?\n/g, '<br>'), linesPerSlideBeamer)
@@ -49,7 +49,7 @@ export function splitSong (text, linesPerSlideLivestream, linesPerSlideBeamer = 
       }
 
       result.slides = chunk(lines, linesPerSlideLivestream)
-      if (!result.slides.length) { result.slides = [['']] }
+      if (!result.slides.length && minOneSlide) { result.slides = [['']] }
 
       return result
     })

--- a/src/components/song/SongSettings.vue
+++ b/src/components/song/SongSettings.vue
@@ -78,26 +78,24 @@
         </div>
         <div class="row q-gutter-md">
           <div class="col">
-            <template v-if="textFormat">
-              <div>
-                <q-avatar icon="text_fields" size="md" />
-                Lied tekst
-              </div>
-              <VezyEditorSong
-                id="inputEditorSong"
-                ref="inputEditorSong"
-                v-model="settings.text"
-                v-model:model-backup="backupSettingText"
-                height="50vh"
-                @scroll="syncInputsEditor('song')"
-              />
-            </template>
+            <div>
+              <q-avatar icon="text_fields" size="md" />
+              Lied tekst
+            </div>
+            <VezyEditorSong
+              v-if="textFormat"
+              id="inputEditorSong"
+              ref="inputEditorSong"
+              v-model="settings.text"
+              v-model:model-backup="backupSettingText"
+              height="50vh"
+              @scroll="syncInputsEditor('song')"
+            />
             <q-input
               v-else
               ref="inputSong"
               v-model="settings.text"
               outlined
-              label="Tekst"
               type="textarea"
               class="input-songtext"
               @scroll="scroll('song')"
@@ -144,52 +142,40 @@
           </div>
 
           <div class="col">
-            <template v-if="textFormat">
-              <div>
-                <q-avatar icon="translate" size="md" />
-                Vertaling
-              </div>
-              <VezyEditorSong
-                id="inputEditorTranslate"
-                ref="inputEditorTranslate"
-                v-model="settings.translation"
-                v-model:model-backup="backupSettingTranslation"
-                height="50vh"
-                :border-read-only="!settings.translation"
-                @scroll="syncInputsEditor('translate')"
-              />
-              <q-toolbar v-if="!settings.translation" class="bg-subtoolbar text-subtoolbar">
-                <q-btn
-                  flat
-                  dense
-                  icon="translate"
-                  label="Automatisch vertalen"
-                  :loading="isTranslating"
-                  @click="translate"
-                />
-              </q-toolbar>
-            </template>
+            <div>
+              <q-avatar icon="translate" size="md" />
+              Vertaling
+            </div>
+            <VezyEditorSong
+              v-if="textFormat"
+              id="inputEditorTranslate"
+              ref="inputEditorTranslate"
+              v-model="settings.translation"
+              v-model:model-backup="backupSettingTranslation"
+              height="50vh"
+              :border-read-only="!settings.translation"
+              @scroll="syncInputsEditor('translate')"
+            />
             <q-input
               v-else
               ref="inputTranslate"
               v-model="settings.translation"
               outlined
-              label="Vertaling"
               type="textarea"
               class="input-songtext"
               :class="{ 'q-field--readonly': !settings.translation }"
               @scroll="scroll('translate')"
-            >
-              <q-btn
-                v-if="!settings.translation"
-                stack
-                icon="translate"
-                label="Automatisch vertalen"
-                class="translation-button"
-                :loading="isTranslating"
-                @click="translate"
-              />
-            </q-input>
+            />
+            <q-btn
+              v-if="!settings.translation"
+              stack
+              icon="translate"
+              label="Automatisch vertalen"
+              text-color="primary"
+              class="translation-button"
+              :loading="isTranslating"
+              @click="translate"
+            />
             <q-toolbar v-if="settings.translation" class="bg-subtoolbar text-subtoolbar">
               <q-btn flat dense label="2 > 1 ⏎" @click.stop="replaceDubbeleNewline(input='translation')">
                 <q-tooltip>Vervang 2 regeleinden door 1</q-tooltip>
@@ -407,7 +393,7 @@ export default {
 .translation-button {
   position: absolute;
   top: 50%;
-  left: 50%;
+  left: 75%;
   transform: translate(-50%, -50%);
 }
 

--- a/src/components/song/SongSettings.vue
+++ b/src/components/song/SongSettings.vue
@@ -84,6 +84,7 @@
                 Lied tekst
               </div>
               <VezyEditorSong
+                id="inputEditorSong"
                 ref="inputEditorSong"
                 v-model="settings.text"
                 v-model:model-backup="backupSettingText"
@@ -149,6 +150,7 @@
                 Vertaling
               </div>
               <VezyEditorSong
+                id="inputEditorTranslate"
                 ref="inputEditorTranslate"
                 v-model="settings.translation"
                 v-model:model-backup="backupSettingTranslation"

--- a/src/components/song/SongSettings.vue
+++ b/src/components/song/SongSettings.vue
@@ -2,6 +2,7 @@
   <div>
     <q-tabs v-model="tab" class="text-grey" active-color="primary" indicator-color="primary" align="left" narrow-indicator :breakpoint="0">
       <q-tab name="text" label="Liedtekst" />
+      <q-tab name="textFormat" label="Liedtekst Opmaak" />
       <q-tab v-if="!editEmit" name="settings" label="Instellingen" />
       <q-tab v-if="!editEmit" name="background" label="Achtergrond" />
     </q-tabs>
@@ -183,6 +184,89 @@
           </div>
         </div>
       </q-tab-panel>
+      <q-tab-panel name="textFormat">
+        <div class="row q-gutter-md">
+          <div class="col">
+            <q-input v-model="settings.title" outlined label="Titel" :rules="['required']" />
+          </div>
+          <div class="col">
+            <div class="row q-gutter-md">
+              <div class="col">
+                <q-input v-model="settings.collection" outlined label="Collectie">
+                  <template #append>
+                    <q-select
+                      v-model="settings.collection"
+                      borderless
+                      hide-selected
+                      menu-anchor="bottom right"
+                      menu-self="top right"
+                      popup-content-style="height: 30vh;"
+                      options-dense
+                      :options="$store.dbCollections"
+                      @click="loadCollectionDatabase"
+                      @popup-show="loadCollectionDatabase"
+                    />
+                  </template>
+                </q-input>
+              </div>
+              <div class="col-2">
+                <q-input v-model="settings.number" outlined label="Nr" />
+              </div>
+              <div v-if="!editEmit" class="col-auto">
+                <q-toggle
+                  v-model="$store.searchBaseIsLocal"
+                  checked-icon="lyrics"
+                  unchecked-icon="cloud"
+                  color="primary"
+                  dense
+                  @update:model-value="$store.dbCollections = ['']"
+                >
+                  <q-tooltip>cloud of locale database</q-tooltip>
+                </q-toggle>
+                <q-btn-dropdown
+                  split
+                  color="primary"
+                  label="Uit database"
+                  icon="lyrics"
+                  class="q-mt-sm"
+                  @click.stop="importSongDb"
+                >
+                  <template #label>
+                    <q-tooltip>Songtekst uit locale database opzoeken</q-tooltip>
+                  </template>
+                  <q-list>
+                    <q-item v-close-popup clickable @click="CompareWithDb">
+                      <q-item-section>
+                        <q-item-label>
+                          Vergelijk met database versie
+                          <q-tooltip>
+                            Lied vergelijken met versie uit de database
+                          </q-tooltip>
+                        </q-item-label>
+                      </q-item-section>
+                    </q-item>
+                  </q-list>
+                </q-btn-dropdown>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="row q-gutter-md">
+          <div class="col">
+            <VezyEditorSong
+              ref="inputEditorSong"
+              v-model="settings.text"
+            />
+          </div>
+
+          <div class="col">
+            <VezyEditorSong
+              ref="inputEditorTranslate"
+              v-model="settings.translation"
+            />
+          </div>
+        </div>
+      </q-tab-panel>
       <q-tab-panel name="settings">
         <div class="row q-gutter-xs">
           <div class="text">
@@ -223,12 +307,13 @@ import SongSettingsTools from './SongSettingsTools.vue'
 import SongArrangeDialog from './SongArrangeDialog.vue'
 import SongDatabaseCompareDialog from './database/SongDatabaseCompareDialog.vue'
 import BackgroundSetting from '../presentation/BackgroundSetting.vue'
+import VezyEditorSong from '../common/VezyEditorSong.vue'
 import { getAlgoliaCollections } from './database/algolia.js'
 import get from 'lodash/get'
 import set from 'lodash/set'
 
 export default {
-  components: { BackgroundSetting, SongArrangeDialog, SongDatabaseCompareDialog },
+  components: { BackgroundSetting, SongArrangeDialog, SongDatabaseCompareDialog, VezyEditorSong },
   extends: SongSettingsTools,
   data () {
     return {

--- a/src/components/song/SongSettings.vue
+++ b/src/components/song/SongSettings.vue
@@ -155,6 +155,7 @@
                 v-model="settings.translation"
                 v-model:model-backup="backupSettingTranslation"
                 height="50vh"
+                :border-read-only="!settings.translation"
                 @scroll="syncInputsEditor('translate')"
               />
               <q-toolbar v-if="!settings.translation" class="bg-subtoolbar text-subtoolbar">


### PR DESCRIPTION
voor nu in los tabblad copy toegevoegd met daarin q-editor (song versie)
- [x] bij nieuw regel springt cursor naar laatste teken terug na run opmaak
  - gebeurd na class en/of style toevoeging aan de <div> zonder blijft cursor positie behouden
  - andere caret met newline positie toegepast dan q-editor caret blijft nu staan
- [x] 1 spatie na tekst wordt bij toepassen opmaak verwijderd; 2 blijven staan; waarom?
  eindspatie naar code omzetten anders niet weergegeven in editor
- [x] algemeen opmaak verder uitwerken
  - hoe rand stippelijn van maken
  - hoe btn vertaling in midden editor 
- [x] caret aanpassen --> lengte in extra child note mogelijjk toepassen wanneer te kort (bijv. in <b>...<span> etc.
  - opgelost door regel op te zoeken in dan char in de regel.
- [x] devtool uit quasar.config halen voor build
