### PR TITLE
ArrowKey Continue Setlist Next or Back

### DIFF
--- a/src/components/caption/CaptionControl.vue
+++ b/src/components/caption/CaptionControl.vue
@@ -1,5 +1,10 @@
 <template>
   <TextSlidesControl v-if="presentation.settings.text" :presentation="presentation" :preview="preview" />
+  <div
+    v-else
+    v-shortkey="{ up: ['arrowup'], down: ['arrowdown'], left: ['arrowleft'], right: ['arrowright'] }"
+    @shortkey="baseHandleArrow"
+  />
 </template>
 
 <script>

--- a/src/components/caption/CaptionControl.vue
+++ b/src/components/caption/CaptionControl.vue
@@ -2,7 +2,7 @@
   <TextSlidesControl v-if="presentation.settings.text" :presentation="presentation" :preview="preview" />
   <div
     v-else
-    v-shortkey="{ up: ['arrowup'], down: ['arrowdown'], left: ['arrowleft'], right: ['arrowright'] }"
+    v-shortkey="shortkeysNextBack"
     @shortkey="baseHandleArrow"
   />
 </template>

--- a/src/components/common/TextSlidesControl.vue
+++ b/src/components/common/TextSlidesControl.vue
@@ -77,7 +77,9 @@ export default {
       const section = this.presentation.control.sections[newSectionIndex]
 
       if (!section) {
-        return
+        if (!this.$store.arrowKeyContinueSetlist || this.preview) return
+        if (change > 0) return this.$store.goLiveNext()
+        return this.$store.goLiveBack()
       }
 
       // Select last or first slide of section, based on going up (-1) or down (+1)

--- a/src/components/common/TextSlidesControl.vue
+++ b/src/components/common/TextSlidesControl.vue
@@ -103,14 +103,19 @@ export default {
       this.select(newSectionIndex, newSlideIndex, true)
     },
     handleArrow (event) {
+      if (event.srcKey === this.$store.lastShortKey) return
       switch (event.srcKey) {
+        case 'pageup':
+          this.$store.setLastShortKey(event.srcKey)
+        // eslint-disable-next-line no-fallthrough
         case 'up':
         case 'left':
-        case 'pageup':
           return this.jump(-1)
+        case 'pagedown':
+          this.$store.setLastShortKey(event.srcKey)
+        // eslint-disable-next-line no-fallthrough
         case 'down':
         case 'right':
-        case 'pagedown':
           return this.jump(+1)
       }
     },

--- a/src/components/common/TextSlidesControl.vue
+++ b/src/components/common/TextSlidesControl.vue
@@ -55,6 +55,14 @@ export default {
     if (!this.presentation.control.selectedSlideIndex) {
       this.presentation.control.selectedSlideIndex = 0
     }
+    // check if back from last item --> start at end
+    if (this.presentation.startEnd) {
+      this.presentation.startEnd = false // reset
+      if (this.presentation.control.sections) {
+        this.presentation.control.selectedSectionIndex = this.presentation.control.sections.length - 1
+        this.presentation.control.selectedSlideIndex = this.presentation.control.sections[this.presentation.control.selectedSectionIndex].slides?.length - 1 || 0
+      }
+    }
   },
   mounted () {
     this.select(this.presentation.control.selectedSectionIndex, this.presentation.control.selectedSlideIndex, true)

--- a/src/components/common/TextSlidesControl.vue
+++ b/src/components/common/TextSlidesControl.vue
@@ -2,7 +2,7 @@
   <q-list
     v-for="(section, sectionIndex) in presentation.control.sections"
     :key="sectionIndex"
-    v-shortkey="{ up: ['arrowup'], down: ['arrowdown'], left: ['arrowleft'], right: ['arrowright'] }"
+    v-shortkey="shortkeysNextBack"
     class="q-py-sm"
     @shortkey="handleArrow"
   >
@@ -42,6 +42,11 @@ import BaseControl from '../presentation/BaseControl.vue'
 
 export default {
   extends: BaseControl,
+  computed: {
+    shortkeysNextBack () {
+      return this.$store.shortkeysNextBack()
+    }
+  },
   created () {
     if (!this.presentation.control) this.presentation.control = {}
     if (!this.presentation.control.selectedSectionIndex) {
@@ -77,7 +82,7 @@ export default {
       const section = this.presentation.control.sections[newSectionIndex]
 
       if (!section) {
-        if (!this.$store.arrowKeyContinueSetlist || this.preview) return
+        if (!this.$store.arrowKeyContinueRemoteSetlist || this.preview) return
         if (change > 0) return this.$store.goLiveNext()
         return this.$store.goLiveBack()
       }
@@ -93,9 +98,11 @@ export default {
       switch (event.srcKey) {
         case 'up':
         case 'left':
+        case 'pageup':
           return this.jump(-1)
         case 'down':
         case 'right':
+        case 'pagedown':
           return this.jump(+1)
       }
     },

--- a/src/components/countdown/CountdownControl.vue
+++ b/src/components/countdown/CountdownControl.vue
@@ -1,5 +1,8 @@
 <template>
-  <q-list>
+  <q-list
+    v-shortkey="{ up: ['arrowup'], down: ['arrowdown'], left: ['arrowleft'], right: ['arrowright'] }"
+    @shortkey="baseHandleArrow"
+  >
     <q-item
       clickable
       class="bg-primary text-white"

--- a/src/components/countdown/CountdownControl.vue
+++ b/src/components/countdown/CountdownControl.vue
@@ -1,6 +1,6 @@
 <template>
   <q-list
-    v-shortkey="{ up: ['arrowup'], down: ['arrowdown'], left: ['arrowleft'], right: ['arrowright'] }"
+    v-shortkey="shortkeysNextBack"
     @shortkey="baseHandleArrow"
   >
     <q-item

--- a/src/components/image/ImageControl.vue
+++ b/src/components/image/ImageControl.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-shortkey="{ up: ['arrowup'], down: ['arrowdown'], left: ['arrowleft'], right: ['arrowright'] }"
+    v-shortkey="shortkeysNextBack"
     @shortkey="baseHandleArrow"
   >
     <q-tabs v-model="presentation.tab" class="text-grey" active-color="primary" indicator-color="primary" align="left" narrow-indicator :breakpoint="0">

--- a/src/components/image/ImageControl.vue
+++ b/src/components/image/ImageControl.vue
@@ -1,5 +1,8 @@
 <template>
-  <div>
+  <div
+    v-shortkey="{ up: ['arrowup'], down: ['arrowdown'], left: ['arrowleft'], right: ['arrowright'] }"
+    @shortkey="baseHandleArrow"
+  >
     <q-tabs v-model="presentation.tab" class="text-grey" active-color="primary" indicator-color="primary" align="left" narrow-indicator :breakpoint="0">
       <q-tab name="both" label="Beamer & Livestream" />
       <q-tab name="beamer" label="Beamer" />

--- a/src/components/layout/Live.vue
+++ b/src/components/layout/Live.vue
@@ -9,7 +9,7 @@
 
       <q-checkbox
         v-model="$store.isClear"
-        v-shortkey="{ctrlc: ['ctrl', 'c'], f6: ['f6']}"
+        v-shortkey="shortkeysClear"
         left-label
         label="Clear"
         color="red"
@@ -69,6 +69,9 @@ export default {
       }
 
       return this.presentationType.name
+    },
+    shortkeysClear () {
+      return this.$store.shortkeysClear()
     }
   }
 }

--- a/src/components/layout/Live.vue
+++ b/src/components/layout/Live.vue
@@ -18,7 +18,7 @@
         <q-tooltip>
           Vink aan om scherm leeg te maken<br>
           Bij beamer & livestream<br>
-          (Ctrl + C of F6)
+          (Ctrl + C of F6 of Spatie)
         </q-tooltip>
       </q-checkbox>
       <q-toggle

--- a/src/components/presentation/BaseControl.vue
+++ b/src/components/presentation/BaseControl.vue
@@ -25,14 +25,19 @@ export default {
     },
     baseHandleArrow (event) {
       if (!this.$store.arrowKeyContinueRemoteSetlist || this.preview) return
+      if (event.srcKey === this.$store.lastShortKey) return
       switch (event.srcKey) {
+        case 'pageup':
+          this.$store.setLastShortKey(event.srcKey)
+        // eslint-disable-next-line no-fallthrough
         case 'up':
         case 'left':
-        case 'pageup':
           return this.$store.goLiveBack()
+        case 'pagedown':
+          this.$store.setLastShortKey(event.srcKey)
+        // eslint-disable-next-line no-fallthrough
         case 'down':
         case 'right':
-        case 'pagedown':
           return this.$store.goLiveNext()
       }
     }

--- a/src/components/presentation/BaseControl.vue
+++ b/src/components/presentation/BaseControl.vue
@@ -19,6 +19,17 @@ export default {
       if (!this.preview) {
         this.$store.unclear()
       }
+    },
+    baseHandleArrow (event) {
+      if (!this.$store.arrowKeyContinueSetlist || this.preview) return
+      switch (event.srcKey) {
+        case 'up':
+        case 'left':
+          return this.$store.goLiveBack()
+        case 'down':
+        case 'right':
+          return this.$store.goLiveNext()
+      }
     }
   }
 }

--- a/src/components/presentation/BaseControl.vue
+++ b/src/components/presentation/BaseControl.vue
@@ -10,6 +10,9 @@ export default {
     },
     clear () {
       return this.$store.isClear
+    },
+    shortkeysNextBack () {
+      return this.$store.shortkeysNextBack()
     }
   },
   methods: {
@@ -21,13 +24,15 @@ export default {
       }
     },
     baseHandleArrow (event) {
-      if (!this.$store.arrowKeyContinueSetlist || this.preview) return
+      if (!this.$store.arrowKeyContinueRemoteSetlist || this.preview) return
       switch (event.srcKey) {
         case 'up':
         case 'left':
+        case 'pageup':
           return this.$store.goLiveBack()
         case 'down':
         case 'right':
+        case 'pagedown':
           return this.$store.goLiveNext()
       }
     }

--- a/src/components/setlist/Setlist.vue
+++ b/src/components/setlist/Setlist.vue
@@ -23,8 +23,7 @@
       </q-checkbox>
       <q-toggle
         v-model="$store.arrowKeyContinueSetlist"
-        checked-icon="repeat"
-        unchecked-icon="repeat"
+        icon="sync_alt"
         color="red"
         dense
       >

--- a/src/components/setlist/Setlist.vue
+++ b/src/components/setlist/Setlist.vue
@@ -22,14 +22,21 @@
         </q-tooltip>
       </q-checkbox>
       <q-toggle
-        v-model="$store.arrowKeyContinueSetlist"
-        icon="sync_alt"
-        color="red"
+        v-model="$store.arrowKeyContinueRemoteSetlist"
+        toggle-indeterminate
+        :false-value="0"
+        :indeterminate-value="1"
+        :true-value="2"
+        unchecked-icon="swap_vert"
+        indeterminate-icon="sync_alt"
+        checked-icon="settings_remote"
+        color="primary"
         dense
       >
         <q-tooltip>
-          Aan: gaat direct door naar volgend of vorige onderdeel in de setlist dmn de pijltoetsen<br>
-          bijv. voor afstandsbedieninggebruik.
+          Uit: Ga via "GoLive" naar nieuwe live onderdeel<br>
+          Midden: Gaat direct door naar volgend of vorige onderdeel in de setlist dmv de pijltoetsen<br>
+          Aan: midden + gebruik van afstandsbediening mogelijk. (toetsen: Page Up/Down werken nu anders.)
         </q-tooltip>
       </q-toggle>
     </q-toolbar>

--- a/src/components/setlist/Setlist.vue
+++ b/src/components/setlist/Setlist.vue
@@ -21,6 +21,18 @@
           (wordt alleen toegepast op nieuw geselecteerde Preview of GoLive)
         </q-tooltip>
       </q-checkbox>
+      <q-toggle
+        v-model="$store.arrowKeyContinueSetlist"
+        checked-icon="repeat"
+        unchecked-icon="repeat"
+        color="red"
+        dense
+      >
+        <q-tooltip>
+          Aan: gaat direct door naar volgend of vorige onderdeel in de setlist dmn de pijltoetsen<br>
+          bijv. voor afstandsbedieninggebruik.
+        </q-tooltip>
+      </q-toggle>
     </q-toolbar>
 
     <div class="layout-column-content">

--- a/src/components/song/SongControl.vue
+++ b/src/components/song/SongControl.vue
@@ -1,5 +1,10 @@
 <template>
   <TextSlidesControl v-if="presentation.settings.text" :presentation="presentation" :preview="preview" />
+  <div
+    v-else
+    v-shortkey="{ up: ['arrowup'], down: ['arrowdown'], left: ['arrowleft'], right: ['arrowright'] }"
+    @shortkey="baseHandleArrow"
+  />
 </template>
 
 <script>

--- a/src/components/song/SongControl.vue
+++ b/src/components/song/SongControl.vue
@@ -2,7 +2,7 @@
   <TextSlidesControl v-if="presentation.settings.text" :presentation="presentation" :preview="preview" />
   <div
     v-else
-    v-shortkey="{ up: ['arrowup'], down: ['arrowdown'], left: ['arrowleft'], right: ['arrowright'] }"
+    v-shortkey="shortkeysNextBack"
     @shortkey="baseHandleArrow"
   />
 </template>

--- a/src/components/video/VideoControl.vue
+++ b/src/components/video/VideoControl.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="q-pa-md">
+  <div
+    v-shortkey="{ up: ['arrowup'], down: ['arrowdown'], left: ['arrowleft'], right: ['arrowright'] }"
+    class="q-pa-md"
+    @shortkey="baseHandleArrow"
+  >
     <video
       ref="player"
       :src="fileUrl"

--- a/src/components/video/VideoControl.vue
+++ b/src/components/video/VideoControl.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-shortkey="{ up: ['arrowup'], down: ['arrowdown'], left: ['arrowleft'], right: ['arrowright'] }"
+    v-shortkey="shortkeysNextBack"
     class="q-pa-md"
     @shortkey="baseHandleArrow"
   >
@@ -21,7 +21,14 @@
   </div>
   <div v-if="duration" class="q-px-md row">
     <div class="q-pa-md col2">
-      <q-btn round color="primary" :icon="iconPlayPause" @click="togglePlayPause">
+      <q-btn
+        v-shortkey="shortkeysPlay"
+        round
+        color="primary"
+        :icon="iconPlayPause"
+        @click="togglePlayPause"
+        @shortkey="togglePlayPause"
+      >
         <q-tooltip>Start/Pause</q-tooltip>
       </q-btn>
     </div>
@@ -81,6 +88,9 @@ export default {
     },
     currentTimeF () {
       return timeFormat(this.currentTime)
+    },
+    shortkeysPlay () {
+      return this.$store.shortkeysPlay()
     }
   },
   watch: {

--- a/src/stores/service.js
+++ b/src/stores/service.js
@@ -6,6 +6,8 @@ import presentationPresets from '../components/presentation-presets'
 import { versionUpdate } from './versionUpdate'
 import { getDefaultURL } from '../components/presets-settings.js'
 
+let clearLastShortKey
+
 export default defineStore('service', {
   state: () => ({
     service: null,
@@ -23,7 +25,8 @@ export default defineStore('service', {
     splitSongLines: localStorage.getItem('splitSongLines') ? parseInt(localStorage.getItem('splitSongLines')) : 4,
     serviceType: localStorage.getItem('serviceType') || 'standaard',
     dbCollections: [''], // start with 1 empty string so showpopup works to load rest
-    message: ''
+    message: '',
+    lastShortKey: ''
   }),
   actions: {
     setServiceSaved () {
@@ -207,6 +210,12 @@ export default defineStore('service', {
     shortkeysPlay () {
       if (this.arrowKeyContinueRemoteSetlist > 1) return { f5: ['f5'], esc: ['esc'] }
       return { }
+    },
+    setLastShortKey (key) {
+      this.lastShortKey = key
+      // reset delayed
+      clearTimeout(clearLastShortKey)
+      clearLastShortKey = setTimeout(() => { this.lastShortKey = '' }, 200)
     },
 
     // Media

--- a/src/stores/service.js
+++ b/src/stores/service.js
@@ -179,6 +179,7 @@ export default defineStore('service', {
       const i = this.service.presentations.findIndex(s => s.id === this.livePresentation.id)
       if (i === 0) return
       const backPresentation = this.service.presentations[i + -1]
+      if (backPresentation) backPresentation.startEnd = true // only used bij textslidescontrole to start at end.
       this.goLive(backPresentation, true)
     },
 

--- a/src/stores/service.js
+++ b/src/stores/service.js
@@ -17,6 +17,7 @@ export default defineStore('service', {
     isClear: true,
     isOnlyLivestreamClear: false,
     noLivestream: false,
+    arrowKeyContinueSetlist: false,
     searchBaseIsLocal: !(localStorage.getItem('database.searchBase') === 'cloud' || false),
     algoliaIndexId: localStorage.getItem('database.algoliaIndexId') ? parseInt(localStorage.getItem('database.algoliaIndexId')) : 0,
     splitSongLines: localStorage.getItem('splitSongLines') ? parseInt(localStorage.getItem('splitSongLines')) : 4,
@@ -168,6 +169,17 @@ export default defineStore('service', {
 
       this.livePresentation = cloneDeep(presentation)
       this.isOnlyLivestreamClear = false
+    },
+    goLiveNext () {
+      if (!this.previewPresentation) return
+      this.goLive(this.previewPresentation, true)
+    },
+    goLiveBack () {
+      if (!this.livePresentation) return
+      const i = this.service.presentations.findIndex(s => s.id === this.livePresentation.id)
+      if (i === 0) return
+      const backPresentation = this.service.presentations[i + -1]
+      this.goLive(backPresentation, true)
     },
 
     // Clear

--- a/src/stores/service.js
+++ b/src/stores/service.js
@@ -196,8 +196,8 @@ export default defineStore('service', {
       this.noLivestream = !this.noLivestream
     },
     shortkeysClear () {
-      if (this.arrowKeyContinueRemoteSetlist > 1) return { ctrlc: ['ctrl', 'c'], f6: ['f6'], period: ['.'] }
-      return { ctrlc: ['ctrl', 'c'], f6: ['f6'] }
+      if (this.arrowKeyContinueRemoteSetlist > 1) return { ctrlc: ['ctrl', 'c'], f6: ['f6'], space: ['space'], period: ['.'] }
+      return { ctrlc: ['ctrl', 'c'], f6: ['f6'], space: ['space'] }
     },
     shortkeysNextBack () {
       if (this.arrowKeyContinueRemoteSetlist > 1) return { up: ['arrowup'], down: ['arrowdown'], left: ['arrowleft'], right: ['arrowright'], pageup: ['pageup'], pagedown: ['pagedown'] }

--- a/src/stores/service.js
+++ b/src/stores/service.js
@@ -17,7 +17,7 @@ export default defineStore('service', {
     isClear: true,
     isOnlyLivestreamClear: false,
     noLivestream: false,
-    arrowKeyContinueSetlist: false,
+    arrowKeyContinueRemoteSetlist: 0, // 0 = false, 1 = true, 2 = true + reomte keys
     searchBaseIsLocal: !(localStorage.getItem('database.searchBase') === 'cloud' || false),
     algoliaIndexId: localStorage.getItem('database.algoliaIndexId') ? parseInt(localStorage.getItem('database.algoliaIndexId')) : 0,
     splitSongLines: localStorage.getItem('splitSongLines') ? parseInt(localStorage.getItem('splitSongLines')) : 4,
@@ -194,6 +194,18 @@ export default defineStore('service', {
     },
     toggleNoLivestream () {
       this.noLivestream = !this.noLivestream
+    },
+    shortkeysClear () {
+      if (this.arrowKeyContinueRemoteSetlist > 1) return { ctrlc: ['ctrl', 'c'], f6: ['f6'], period: ['.'] }
+      return { ctrlc: ['ctrl', 'c'], f6: ['f6'] }
+    },
+    shortkeysNextBack () {
+      if (this.arrowKeyContinueRemoteSetlist > 1) return { up: ['arrowup'], down: ['arrowdown'], left: ['arrowleft'], right: ['arrowright'], pageup: ['pageup'], pagedown: ['pagedown'] }
+      return { up: ['arrowup'], down: ['arrowdown'], left: ['arrowleft'], right: ['arrowright'] }
+    },
+    shortkeysPlay () {
+      if (this.arrowKeyContinueRemoteSetlist > 1) return { f5: ['f5'], esc: ['esc'] }
+      return { }
     },
 
     // Media


### PR DESCRIPTION
- #300
- nu ingesteld dat live kolom arrow-keys bovenin of aan einde golivenext/goliveback uitvoeren.
 
todo:
- [x] check knoppen afstandbediening --> welke key's
  - up/down/left/right
  - clear
  - ...
- [x] omgekeerde debounce op afstandsbediening knop (per type) zodat ingedrukt houden niet heel vaak alles uit voert.
(v-shortkey.once --> komt alleen bij key-up, niet handig)
- [x] bij back naar textcontrol --> start onderaan ipv vanaf begin
- [x] toggle icon continue setlist: (nu repeat; misschien voor/acheruit pijlen beter; zoeken of die er is.
- [ ] actieve kolom kiezen (setlist / preview / live) die event.key ontvangt
  - nu bij image/countdown etc niet te doen
  - bij text control alleen te doen door op een ander item te kiezen welke niet actief is (bij actief item blijft hij op de oude staan.)
  @jpkleemans heb jij idee hoe dit te doen? 