### PR TITLE
add background hergebruik image

### DIFF
--- a/src/boot/filesystem.js
+++ b/src/boot/filesystem.js
@@ -45,6 +45,8 @@ const fs = {
       // Load media into store
       const mediaEntries = entries.filter(e => e.filename !== 'service.json')
 
+      if (!add) store.clearMediaBut() // clear media list by open new setlist
+
       for (const file of mediaEntries) {
         const blob = await file.getData(new zip.BlobWriter())
 

--- a/src/boot/filesystem.js
+++ b/src/boot/filesystem.js
@@ -102,6 +102,7 @@ const fs = {
     // Add media files to zip
     for (const [fileId, fileUrl] of Object.entries(store.media)) {
       if (!service.includes(fileId)) {
+        store.removeMedia(fileId) // File isn't used anymore, remove from list
         continue // File isn't used anymore, so don't save it
       }
       // Read the file from its url

--- a/src/boot/filesystem.js
+++ b/src/boot/filesystem.js
@@ -45,7 +45,7 @@ const fs = {
       // Load media into store
       const mediaEntries = entries.filter(e => e.filename !== 'service.json')
 
-      if (!add) store.clearMediaBut() // clear media list by open new setlist
+      if (!add) store.cleanMedia(null, false) // clear media list by open new setlist
 
       for (const file of mediaEntries) {
         const blob = await file.getData(new zip.BlobWriter())

--- a/src/components/help/HelpCaption.vue
+++ b/src/components/help/HelpCaption.vue
@@ -94,6 +94,7 @@
     <p>
       Onder het tabblad "achtergrond" kan je eventueel een afwijkende achtergrond kiezen voor dit onderdeel.<br>
       Tevens kan je hier de achtergrond donkerder maken voor bijv. leesbaarheid teksten. (nvt tijdens clear)<br>
+      Nadat er reeds afbeeldingen zijn gebruikt, kan je deze ook hergebruiken door deze via het uitklapvenster te selecteren.<br>
       <img src="../../assets/help/scriptureachtergronddialog.png"><br>
       <img src="../../assets/help/achtergronddonkerder.png">
     </p>

--- a/src/components/help/HelpCountdown.vue
+++ b/src/components/help/HelpCountdown.vue
@@ -24,6 +24,7 @@
     <p>
       Onder het tabblad "achtergrond" kan je eventueel een afwijkende achtergrond kiezen voor dit onderdeel.<br>
       Tevens kan je hier de achtergrond donkerder maken voor bijv. leesbaarheid teksten. (nvt tijdens clear)<br>
+      Nadat er reeds afbeeldingen zijn gebruikt, kan je deze ook hergebruiken door deze via het uitklapvenster te selecteren.<br>
       <img src="../../assets/help/scriptureachtergronddialog.png"><br>
       <img src="../../assets/help/achtergronddonkerder.png">
     </p>

--- a/src/components/help/HelpImage.vue
+++ b/src/components/help/HelpImage.vue
@@ -116,6 +116,7 @@
     <p>
       Onder het tabblad "achtergrond" kan je eventueel een afwijkende achtergrond kiezen voor dit onderdeel.<br>
       Tevens kan je hier de achtergrond donkerder maken voor bijv. leesbaarheid teksten. (nvt tijdens clear)<br>
+      Nadat er reeds afbeeldingen zijn gebruikt, kan je deze ook hergebruiken door deze via het uitklapvenster te selecteren.<br>
       <img src="../../assets/help/scriptureachtergronddialog.png"><br>
       <img src="../../assets/help/achtergronddonkerder.png">
     </p>

--- a/src/components/help/HelpScripture.vue
+++ b/src/components/help/HelpScripture.vue
@@ -84,6 +84,7 @@
     <p>
       Onder het tabblad "achtergrond" kan je eventueel een afwijkende achtergrond kiezen voor dit onderdeel.<br>
       Tevens kan je hier de achtergrond donkerder maken voor bijv. leesbaarheid teksten. (nvt tijdens clear)<br>
+      Nadat er reeds afbeeldingen zijn gebruikt, kan je deze ook hergebruiken door deze via het uitklapvenster te selecteren.<br>
       <img src="../../assets/help/scriptureachtergronddialog.png"><br>
       <img src="../../assets/help/achtergronddonkerder.png">
     </p>

--- a/src/components/help/HelpSong.vue
+++ b/src/components/help/HelpSong.vue
@@ -215,6 +215,7 @@
     <p>
       Je komt nu weer terug in het zelfde scherm als je hebt gebruikt bij toevoegen van het onderdeel.<br>
       <i>Let op dat alle wijzigingen die je aanbrengt direct worden toegepast in de setlist.</i> (excl. het onderdeel in live).<br>
+      Nadat er reeds afbeeldingen zijn gebruikt, kan je deze ook hergebruiken door deze via het uitklapvenster te selecteren.<br>
     </p>
     <div class="text-h6 q-mb-md">
       Lijst toepasbare labels

--- a/src/components/help/HelpVideo.vue
+++ b/src/components/help/HelpVideo.vue
@@ -61,6 +61,7 @@
     <p>
       Onder het tabblad "achtergrond" kan je eventueel een afwijkende achtergrond kiezen voor dit onderdeel.<br>
       Tevens kan je hier de achtergrond donkerder maken voor bijv. leesbaarheid teksten. (nvt tijdens clear)<br>
+      Nadat er reeds afbeeldingen zijn gebruikt, kan je deze ook hergebruiken door deze via het uitklapvenster te selecteren.<br>
       <img src="../../assets/help/scriptureachtergronddialog.png"><br>
       <img src="../../assets/help/achtergronddonkerder.png">
     </p>

--- a/src/components/image/ImageSelect.vue
+++ b/src/components/image/ImageSelect.vue
@@ -1,9 +1,22 @@
 <template>
-  <q-file v-model="file" accept="image/*" :label="label" :loading="isLoading" outlined @update:model-value="updateFile">
-    <template #prepend>
-      <q-icon name="image" />
-    </template>
-  </q-file>
+  <div class="row">
+    <q-file v-model="file" accept="image/*" :label="label" :loading="isLoading" outlined class="col" @update:model-value="updateFile">
+      <template #prepend>
+        <q-icon name="image" />
+      </template>
+    </q-file>
+    <q-btn-dropdown v-if="imageIds.length" :disable="!imageIds.length" flat>
+      <q-list>
+        <q-item v-for="id in imageIds" :key="id" v-close-popup clickable @click="addMedia(id)">
+          <q-item-section>
+            <q-img :src="$store.getMediaUrl(id)" loading="lazy" fit="contain" height="8vh" width="16vh">
+              <q-tooltip>{{ id }}</q-tooltip>
+            </q-img>
+          </q-item-section>
+        </q-item>
+      </q-list>
+    </q-btn-dropdown>
+  </div>
 
   <div v-if="fileUrl" class="q-mt-md">
     <!-- Zoom -->
@@ -124,6 +137,9 @@ export default {
     },
     factor () {
       return this.$store.outputRatio / this.settings.ratio
+    },
+    imageIds () {
+      return this.$store.getImageIds()
     }
   },
   methods: {
@@ -137,7 +153,16 @@ export default {
 
       this.isLoading = false
     },
-    getImageRatio (file) {
+    async addMedia (id) {
+      this.file = null
+      this.isLoading = true
+
+      this.settings.ratio = await this.getImageRatio(null, id)
+      this.settings.fileId = id
+
+      this.isLoading = false
+    },
+    getImageRatio (file, id = 0) {
       return new Promise((resolve) => {
         const img = new Image()
 
@@ -150,7 +175,7 @@ export default {
           resolve(1) // Default to 1:1 ratio if something goes wrong
         }
 
-        img.src = URL.createObjectURL(file)
+        img.src = id ? this.$store.getMediaUrl(id) : URL.createObjectURL(file)
       })
     },
     fit () {

--- a/src/components/image/ImageSelect.vue
+++ b/src/components/image/ImageSelect.vue
@@ -18,7 +18,7 @@
     </q-btn-dropdown>
   </div>
 
-  <div v-if="fileUrl" class="q-mt-md">
+  <div v-if="fileUrl && settings.ratio" class="q-mt-md">
     <!-- Zoom -->
     <div v-if="settings.advanced" class="row">
       <div class="col-narrow">

--- a/src/components/image/ImageSelect.vue
+++ b/src/components/image/ImageSelect.vue
@@ -7,7 +7,7 @@
     </q-file>
     <q-btn-dropdown v-if="imageIds.length" :disable="!imageIds.length" flat>
       <q-list>
-        <q-item v-for="id in imageIds" :key="id" v-close-popup clickable @click="addMedia(id)">
+        <q-item v-for="id in imageIds" :key="id" v-close-popup clickable @click="setMedia(id)">
           <q-item-section>
             <q-img :src="$store.getMediaUrl(id)" loading="lazy" fit="contain" height="8vh" width="16vh">
               <q-tooltip>{{ id }}</q-tooltip>
@@ -136,7 +136,10 @@ export default {
       return this.$store.getMediaUrl(this.settings.fileId)
     },
     factor () {
-      return this.$store.outputRatio / this.settings.ratio
+      if (this.$store.outputRatio && this.settings.ratio) {
+        return this.$store.outputRatio / this.settings.ratio
+      }
+      return 1
     },
     imageIds () {
       return this.$store.getImageIds()
@@ -146,23 +149,23 @@ export default {
     async updateFile (file) {
       this.isLoading = true
 
-      this.settings.ratio = await this.getImageRatio(file)
       this.settings.fileId = this.$store.addMedia(file)
+      this.settings.ratio = await this.getImageRatio(this.settings.fileId)
 
       this.$emit('updateFile', file)
 
       this.isLoading = false
     },
-    async addMedia (id) {
+    async setMedia (id) {
       this.file = null
       this.isLoading = true
 
-      this.settings.ratio = await this.getImageRatio(null, id)
       this.settings.fileId = id
+      this.settings.ratio = await this.getImageRatio(id)
 
       this.isLoading = false
     },
-    getImageRatio (file, id = 0) {
+    getImageRatio (id) {
       return new Promise((resolve) => {
         const img = new Image()
 
@@ -175,7 +178,7 @@ export default {
           resolve(1) // Default to 1:1 ratio if something goes wrong
         }
 
-        img.src = id ? this.$store.getMediaUrl(id) : URL.createObjectURL(file)
+        img.src = this.$store.getMediaUrl(id)
       })
     },
     fit () {

--- a/src/components/image/ImageSettings.vue
+++ b/src/components/image/ImageSettings.vue
@@ -100,7 +100,7 @@ export default {
       }
     },
     updateTitle (file) {
-      this.settings.title = file.name
+      if (file) this.settings.title = file.name
     },
     setPreset (id) {
       const preset = this.presentationPresets.find(p => p.id === id)

--- a/src/components/presentation/BackgroundSetting.vue
+++ b/src/components/presentation/BackgroundSetting.vue
@@ -11,7 +11,7 @@
     </q-file>
     <q-btn-dropdown v-if="imageIds.length" :disable="!imageIds.length" flat>
       <q-list>
-        <q-item v-for="id in imageIds" :key="id" v-close-popup clickable @click="addMedia(id)">
+        <q-item v-for="id in imageIds" :key="id" v-close-popup clickable @click="setMedia(id)">
           <q-item-section>
             <q-img :src="$store.getMediaUrl(id)" loading="lazy" fit="contain" height="8vh" width="16vh">
               <q-tooltip>{{ id }}</q-tooltip>
@@ -104,7 +104,7 @@ export default {
     updateBackground (file) {
       this.$emit('update:bgFileId', this.$store.addMedia(file))
     },
-    addMedia (id) {
+    setMedia (id) {
       this.background = null
       this.$emit('update:bgFileId', id)
     },

--- a/src/components/presentation/BackgroundSetting.vue
+++ b/src/components/presentation/BackgroundSetting.vue
@@ -1,13 +1,26 @@
 <template>
-  <q-file v-model="background" accept="image/*" label="Selecteer eventueel een afwijkende achtergrondafbeelding (beamer)" outlined @update:model-value="updateBackground">
-    <template #prepend>
-      <q-icon name="image" />
-    </template>
+  <div class="row">
+    <q-file v-model="background" accept="image/*" label="Selecteer eventueel een afwijkende achtergrondafbeelding (beamer)" outlined class="col" @update:model-value="updateBackground">
+      <template #prepend>
+        <q-icon name="image" />
+      </template>
 
-    <template v-if="bgFileId" #append>
-      <q-icon name="cancel" class="cursor-pointer" @click="resetBackground" />
-    </template>
-  </q-file>
+      <template v-if="bgFileId" #append>
+        <q-icon name="cancel" class="cursor-pointer" @click="resetBackground" />
+      </template>
+    </q-file>
+    <q-btn-dropdown v-if="imageIds.length" :disable="!imageIds.length">
+      <q-list>
+        <q-item v-for="id in imageIds" :key="id" v-close-popup clickable @click="addMedia(id)">
+          <q-item-section>
+            <q-img :src="$store.getMediaUrl(id)" loading="lazy" fit="contain" height="8vh" width="16vh">
+              <q-tooltip>{{ id }}</q-tooltip>
+            </q-img>
+          </q-item-section>
+        </q-item>
+      </q-list>
+    </q-btn-dropdown>
+  </div>
   <div class="q-mt-sm preview">
     <q-responsive :ratio="ratio" class="output-preview">
       <div class="bg-output-beamer" :style="style">
@@ -79,6 +92,9 @@ export default {
     },
     ratio () {
       return this.$store.outputRatio
+    },
+    imageIds () {
+      return this.$store.getImageIds()
     }
   },
   methods: {
@@ -87,6 +103,10 @@ export default {
     },
     updateBackground (file) {
       this.$emit('update:bgFileId', this.$store.addMedia(file))
+    },
+    addMedia (id) {
+      this.background = null
+      this.$emit('update:bgFileId', id)
     },
     resetBackground () {
       this.$emit('update:bgFileId', null)

--- a/src/components/presentation/BackgroundSetting.vue
+++ b/src/components/presentation/BackgroundSetting.vue
@@ -9,7 +9,7 @@
         <q-icon name="cancel" class="cursor-pointer" @click="resetBackground" />
       </template>
     </q-file>
-    <q-btn-dropdown v-if="imageIds.length" :disable="!imageIds.length">
+    <q-btn-dropdown v-if="imageIds.length" :disable="!imageIds.length" flat>
       <q-list>
         <q-item v-for="id in imageIds" :key="id" v-close-popup clickable @click="addMedia(id)">
           <q-item-section>

--- a/src/components/service/ServiceSettingsDialog.vue
+++ b/src/components/service/ServiceSettingsDialog.vue
@@ -41,9 +41,12 @@
             <q-input v-model="service.worshiplead" label="Aanbiddingsleider" :rules="['required']" />
 
             <div class="row">
-              <q-file v-model="backgroundImageFile" accept="image/*" label="Achtergrondafbeelding" clearable class="col" @update:model-value="updateBackgroundImage">
+              <q-file v-model="backgroundImageFile" accept="image/*" label="Achtergrondafbeelding" class="col" @update:model-value="updateBackgroundImage">
                 <template #prepend>
                   <q-icon name="image" />
+                </template>
+                <template v-if="service.backgroundImageId" #append>
+                  <q-icon name="cancel" class="cursor-pointer" @click="resetBackgroundImage" />
                 </template>
               </q-file>
               <q-btn-dropdown v-if="imageIds.length && !isNew" :disable="!imageIds.length" flat>
@@ -143,6 +146,10 @@ export default {
         return
       }
       this.service.backgroundImageId = this.$store.addMedia(file)
+    },
+    resetBackgroundImage () {
+      this.backgroundImageFile = null
+      this.service.backgroundImageId = null
     },
     addMedia (id) {
       this.backgroundImageFile = null

--- a/src/components/service/ServiceSettingsDialog.vue
+++ b/src/components/service/ServiceSettingsDialog.vue
@@ -158,7 +158,7 @@ export default {
     save () {
       if (this.isNew) {
         this.$fs.fileHandle = null
-        this.$store.clearMediaBut(this.service.backgroundImageId)
+        this.$store.cleanMedia(this.service.backgroundImageId, false)
       }
       this.$store.fillService(this.service)
       this.$refs.pco.addItems()

--- a/src/components/service/ServiceSettingsDialog.vue
+++ b/src/components/service/ServiceSettingsDialog.vue
@@ -51,7 +51,7 @@
               </q-file>
               <q-btn-dropdown v-if="imageIds.length && !isNew" :disable="!imageIds.length" flat>
                 <q-list>
-                  <q-item v-for="id in imageIds" :key="id" v-close-popup clickable @click="addMedia(id)">
+                  <q-item v-for="id in imageIds" :key="id" v-close-popup clickable @click="setMedia(id)">
                     <q-item-section>
                       <q-img :src="$store.getMediaUrl(id)" loading="lazy" fit="contain" height="8vh" width="16vh">
                         <q-tooltip>{{ id }}</q-tooltip>
@@ -151,7 +151,7 @@ export default {
       this.backgroundImageFile = null
       this.service.backgroundImageId = null
     },
-    addMedia (id) {
+    setMedia (id) {
       this.backgroundImageFile = null
       this.service.backgroundImageId = id
     },

--- a/src/components/service/ServiceSettingsDialog.vue
+++ b/src/components/service/ServiceSettingsDialog.vue
@@ -40,11 +40,24 @@
             <q-input v-model="service.preacher" label="Spreker" :rules="['required']" />
             <q-input v-model="service.worshiplead" label="Aanbiddingsleider" :rules="['required']" />
 
-            <q-file v-model="backgroundImageFile" accept="image/*" label="Achtergrondafbeelding" clearable @update:model-value="updateBackgroundImage">
-              <template #prepend>
-                <q-icon name="image" />
-              </template>
-            </q-file>
+            <div class="row">
+              <q-file v-model="backgroundImageFile" accept="image/*" label="Achtergrondafbeelding" clearable class="col" @update:model-value="updateBackgroundImage">
+                <template #prepend>
+                  <q-icon name="image" />
+                </template>
+              </q-file>
+              <q-btn-dropdown v-if="imageIds.length" :disable="!imageIds.length" flat>
+                <q-list>
+                  <q-item v-for="id in imageIds" :key="id" v-close-popup clickable @click="addMedia(id)">
+                    <q-item-section>
+                      <q-img :src="$store.getMediaUrl(id)" loading="lazy" fit="contain" height="8vh" width="16vh">
+                        <q-tooltip>{{ id }}</q-tooltip>
+                      </q-img>
+                    </q-item-section>
+                  </q-item>
+                </q-list>
+              </q-btn-dropdown>
+            </div>
 
             <img v-if="backgroundImageUrl" :src="backgroundImageUrl" class="full-width">
           </q-card-section>
@@ -94,6 +107,9 @@ export default {
     },
     isNew () {
       return !this.service.id
+    },
+    imageIds () {
+      return this.$store.getImageIds()
     }
   },
   methods: {
@@ -127,6 +143,10 @@ export default {
         return
       }
       this.service.backgroundImageId = this.$store.addMedia(file)
+    },
+    addMedia (id) {
+      this.backgroundImageFile = null
+      this.service.backgroundImageId = id
     },
     save () {
       if (this.isNew) this.$fs.fileHandle = null

--- a/src/components/service/ServiceSettingsDialog.vue
+++ b/src/components/service/ServiceSettingsDialog.vue
@@ -46,7 +46,7 @@
                   <q-icon name="image" />
                 </template>
               </q-file>
-              <q-btn-dropdown v-if="imageIds.length" :disable="!imageIds.length" flat>
+              <q-btn-dropdown v-if="imageIds.length && !isNew" :disable="!imageIds.length" flat>
                 <q-list>
                   <q-item v-for="id in imageIds" :key="id" v-close-popup clickable @click="addMedia(id)">
                     <q-item-section>
@@ -149,7 +149,10 @@ export default {
       this.service.backgroundImageId = id
     },
     save () {
-      if (this.isNew) this.$fs.fileHandle = null
+      if (this.isNew) {
+        this.$fs.fileHandle = null
+        this.$store.clearMediaBut(this.service.backgroundImageId)
+      }
       this.$store.fillService(this.service)
       this.$refs.pco.addItems()
       this.hide()

--- a/src/components/service/ServiceSettingsDialog.vue
+++ b/src/components/service/ServiceSettingsDialog.vue
@@ -109,7 +109,7 @@ export default {
       return this.$store.getMediaUrl(this.service.backgroundImageId)
     },
     isNew () {
-      return !this.service.id
+      return !this.service?.id
     },
     imageIds () {
       return this.$store.getImageIds()
@@ -117,6 +117,10 @@ export default {
   },
   methods: {
     show (service = null) {
+      // reset dialog by open
+      this.backgroundImageFile = null
+      this.pcoDialog = false
+
       const defaults = {
         date: dayjs().day(7).format('YYYY/MM/DD'), // Next sunday
         time: '09:30',

--- a/src/stores/service.js
+++ b/src/stores/service.js
@@ -256,8 +256,19 @@ export default defineStore('service', {
       return this.media[id]
     },
     getImageIds () {
-      return Object.keys(this.media)
-      // Nu zowel image als video; video er nog uit filteren.
+      const imageExt = ['png', 'jpg', 'gif', 'tga', 'tif']
+      const videoExt = ['mp4', 'mov', 'avi', 'wmv', 'vob', 'mpg', 'mp2', 'mpv2', 'mpe', 'mpeg', 'mpev2']
+      let mediaIds = Object.keys(this.media)
+      if (mediaIds.length) {
+        mediaIds = mediaIds.filter((id) => {
+          const ext = id.split('.').pop().toLowerCase()
+          if (imageExt.includes(ext)) return true
+          if (videoExt.includes(ext)) return false
+          // Nu wannneer extentie niet bekend, vanuitgaan dat image is
+          return true
+        })
+      }
+      return mediaIds
     }
   }
 })

--- a/src/stores/service.js
+++ b/src/stores/service.js
@@ -241,6 +241,15 @@ export default defineStore('service', {
 
       return id
     },
+    clearMediaBut (id = 0) {
+      if (id) {
+        const mediaId = this.media[id]
+        this.media = {}
+        this.media[id] = mediaId
+      } else {
+        this.media = {}
+      }
+    },
     getMediaUrl (id) {
       if (!id) {
         return null

--- a/src/stores/service.js
+++ b/src/stores/service.js
@@ -241,13 +241,24 @@ export default defineStore('service', {
 
       return id
     },
+    removeMedia (id, check = false) {
+      if (!id) {
+        return null
+      }
+      if (id.startsWith('/')) {
+        return null
+      }
+      // check if not used:
+      if (!check || !JSON.stringify(this.service).includes(id)) {
+        URL.revokeObjectURL(this.media[id])
+        delete this.media[id]
+      }
+    },
     clearMediaBut (id = 0) {
-      if (id) {
-        const mediaId = this.media[id]
-        this.media = {}
-        this.media[id] = mediaId
-      } else {
-        this.media = {}
+      for (const mediaId of Object.keys(this.media)) {
+        if (mediaId !== id) {
+          this.removeMedia(mediaId)
+        }
       }
     },
     getMediaUrl (id) {

--- a/src/stores/service.js
+++ b/src/stores/service.js
@@ -254,6 +254,10 @@ export default defineStore('service', {
       }
 
       return this.media[id]
+    },
+    getImageIds () {
+      return Object.keys(this.media)
+      // Nu zowel image als video; video er nog uit filteren.
     }
   }
 })

--- a/src/stores/service.js
+++ b/src/stores/service.js
@@ -256,14 +256,14 @@ export default defineStore('service', {
       return this.media[id]
     },
     getImageIds () {
-      const imageExt = ['png', 'jpg', 'gif', 'tga', 'tif']
+      // const imageExt = ['png', 'jpg', 'gif', 'tga', 'tif', 'jpeg']
       const videoExt = ['mp4', 'mov', 'avi', 'wmv', 'vob', 'mpg', 'mp2', 'mpv2', 'mpe', 'mpeg', 'mpev2']
       let mediaIds = Object.keys(this.media)
       if (mediaIds.length) {
         mediaIds = mediaIds.filter((id) => {
           const ext = id.split('.').pop().toLowerCase()
-          if (imageExt.includes(ext)) return true
           if (videoExt.includes(ext)) return false
+          // if (imageExt.includes(ext)) return true
           // Nu wannneer extentie niet bekend, vanuitgaan dat image is
           return true
         })

--- a/src/stores/service.js
+++ b/src/stores/service.js
@@ -248,16 +248,18 @@ export default defineStore('service', {
       if (id.startsWith('/')) {
         return null
       }
-      // check if not used:
+      // check if not used in service, preview or live:
       if (!check || !JSON.stringify(this.service).includes(id)) {
-        URL.revokeObjectURL(this.media[id])
-        delete this.media[id]
+        if (!JSON.stringify(this.livePresentation).includes(id) && !JSON.stringify(this.previewPresentation).includes(id)) {
+          URL.revokeObjectURL(this.media[id])
+          delete this.media[id]
+        }
       }
     },
-    clearMediaBut (id = 0) {
+    cleanMedia (notId, check = false) {
       for (const mediaId of Object.keys(this.media)) {
-        if (mediaId !== id) {
-          this.removeMedia(mediaId)
+        if (mediaId !== notId) {
+          this.removeMedia(mediaId, check)
         }
       }
     },


### PR DESCRIPTION
- [x] filter media id --> images --> voor nu op simpele extensie lijst gedaan. 
_(niet 100% waterdicht, kan een leeg menu item opleveren wanneer er tog een geen plaatje bestand tussen zit; maar wel snel en denk dat de meest gebruikte extenties er nu in zitten)_
- [x] add image bg from menu
- [x] add image item from menu --> dan ook ratio e.d. ophalen
- [x] add image bg from menu by service settings
- [x] media list werd steeds voller bij openen vezy bestanden of new (oude bleven staan) --> Nu leeg gehaald bij new en open + blob ook verwijderen om geheugen te sparen. en bij save niet gebruikte verwijderd.
- [x] fix: bij opvragen ratio werd een extra blob geplaatst, maar niet verwijderd; en ook 1 bij saven.

