### PR TITLE
351 vastlopen na filmpje

### DIFF
--- a/src/components/video/VideoControl.vue
+++ b/src/components/video/VideoControl.vue
@@ -1,60 +1,62 @@
 <template>
-  <div
-    v-shortkey="shortkeysNextBack"
-    class="q-pa-md"
-    @shortkey="baseHandleArrow"
-    @click="setHandleArrowLocation"
-  >
-    <video
-      ref="player"
-      :src="fileUrl"
-      preload="auto"
-      muted
-      class="full-width"
-      playsinline
-      disablePictureInPicture
-      controlsList="nodownload noremoteplayback noplaybackrate"
-      x-webkit-airplay="deny"
-      @timeupdate="timeupdate"
-      @loadedmetadata="loadedmetadata"
-      @canplaythrough="canplaythrough"
-    />
-  </div>
-  <div v-if="duration" class="q-px-md row">
-    <div class="q-pa-md col2">
-      <q-btn
-        v-shortkey="shortkeysPlay"
-        round
-        color="primary"
-        :icon="iconPlayPause"
-        @click="togglePlayPause"
-        @shortkey="togglePlayPause"
-      >
-        <q-tooltip>Start/Pause</q-tooltip>
-      </q-btn>
-    </div>
-    <div class="q-px-md col">
-      <q-badge color="secondary">
-        {{ `${currentTimeF} (${settings.play ? 'Bezig met afspelen' : 'gestopt'})` }}
-      </q-badge>
-      <q-slider
-        v-model="currentTime"
-        track-size="1vh"
-        color="primary"
-        inner-track-color="secondary"
-        :min="0"
-        :max="duration"
-        :inner-min="settings.startTime"
-        :inner-max="settings.endTime"
-        label
-        :label-value="currentTimeF"
-        :marker-labels="markerLabels"
-        @pan="moveTime"
-        @click="moveTime"
+  <div>
+    <div
+      v-shortkey="shortkeysNextBack"
+      class="q-pa-md"
+      @shortkey="baseHandleArrow"
+      @click="setHandleArrowLocation"
+    >
+      <video
+        ref="player"
+        :src="fileUrl"
+        preload="auto"
+        muted
+        class="full-width"
+        playsinline
+        disablePictureInPicture
+        controlsList="nodownload noremoteplayback noplaybackrate"
+        x-webkit-airplay="deny"
+        @timeupdate="timeupdate"
+        @loadedmetadata="loadedmetadata"
+        @canplaythrough="canplaythrough"
       />
     </div>
-    <div class="q-px-md col2">
-      <h6>{{ remainingF }}</h6>
+    <div v-if="duration" class="q-px-md row">
+      <div class="q-pa-md col2">
+        <q-btn
+          v-shortkey="shortkeysPlay"
+          round
+          color="primary"
+          :icon="iconPlayPause"
+          @click="togglePlayPause"
+          @shortkey="togglePlayPause"
+        >
+          <q-tooltip>Start/Pause</q-tooltip>
+        </q-btn>
+      </div>
+      <div class="q-px-md col">
+        <q-badge color="secondary">
+          {{ `${currentTimeF} (${settings.play ? 'Bezig met afspelen' : 'gestopt'})` }}
+        </q-badge>
+        <q-slider
+          v-model="currentTime"
+          track-size="1vh"
+          color="primary"
+          inner-track-color="secondary"
+          :min="0"
+          :max="duration"
+          :inner-min="settings.startTime"
+          :inner-max="settings.endTime"
+          label
+          :label-value="currentTimeF"
+          :marker-labels="markerLabels"
+          @pan="moveTime"
+          @click="moveTime"
+        />
+      </div>
+      <div class="q-px-md col2">
+        <h6>{{ remainingF }}</h6>
+      </div>
     </div>
   </div>
 </template>
@@ -71,7 +73,9 @@ export default {
       readyStateFirst: -1,
       moveSlider: false,
       movePlayState: false,
-      markerLabels: []
+      markerLabels: [],
+      setTimeoutIdPlay: null,
+      setTimeoutIdPauze: null
     }
   },
   computed: {
@@ -107,11 +111,13 @@ export default {
       this.player.currentTime = val
     },
     'currentTime' (val) {
+      if (!this.player) return
       if (val >= this.settings.endTime) this.end()
       if (!this.moveSlider) return
       this.settings.time = val
     },
     'remainingF' (val) {
+      if (!this.player) return
       this.settings.remainingF = val
     },
     clear (val) {
@@ -122,13 +128,18 @@ export default {
         return
       }
 
-      setTimeout(() => this.pause(), 300)
+      if (this.setTimeoutIdPauze) clearTimeout(this.setTimeoutIdPauze) // no dubble
+      this.setTimeoutIdPauze = setTimeout(() => this.pause(), 300)
     }
   },
   mounted () {
     this.pause()
     this.readyStateFirst = -1
     if (this.preview) this.settings.time = this.settings.startTime
+  },
+  unmouted () {
+    if (this.setTimeoutIdPlay) clearTimeout(this.setTimeoutIdPlay)
+    if (this.setTimeoutIdPauze) clearTimeout(this.setTimeoutIdPauze)
   },
   methods: {
     togglePlayPause () {
@@ -152,8 +163,9 @@ export default {
       this.settings.time = this.currentTime
     },
     play () {
-      if (this.player.readyState < 4) {
-        setTimeout(() => this.play(), 50)
+      if (!this.player || this.player.readyState < 4) {
+        if (this.setTimeoutIdPlay) clearTimeout(this.setTimeoutIdPlay) // no dubble
+        this.setTimeoutIdPlay = setTimeout(() => this.play(), 50)
         return
       }
       this.settings.play = true

--- a/src/components/video/VideoOutput.vue
+++ b/src/components/video/VideoOutput.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="bg-output" :style="styleBgBeamer">
+    <Transition name="q-transition--fade">
+      <div v-if="alpha" v-show="!clear && show" class="alpha" :style="styleOpacityBeamer" />
+      <video v-else v-show="!clear && show" ref="player" :muted="muted" :src="fileUrl" class="video" />
+    </Transition>
+  </div>
+</template>
+
+<script>
+import BaseOutput from '../output/BaseOutput.vue'
+
+export default {
+  extends: BaseOutput,
+  props: {
+    muted: Boolean,
+    outputlivestream: Boolean
+  },
+  computed: {
+    fileUrl () {
+      return this.$store.getMediaUrl(this.settings.fileId)
+    },
+    player () {
+      return this.$refs.player
+    },
+    show () {
+      if (!this.outputlivestream) return true
+      return !this.settings.noLivestream
+    }
+  },
+  watch: {
+    'settings.play' (val) {
+      if (!this.player) return
+
+      val ? this.player.play() : this.player.pause()
+    },
+    'settings.time' (val) {
+      if (!this.player) return
+
+      this.player.currentTime = val
+    }
+  }
+}
+</script>
+
+<style scoped>
+.video,
+.alpha {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+}
+
+.alpha {
+  background: #fff;
+}
+</style>

--- a/src/components/video/VideoOutputBeamer.vue
+++ b/src/components/video/VideoOutputBeamer.vue
@@ -1,57 +1,13 @@
 <template>
-  <div class="bg-output" :style="styleBgBeamer">
-    <Transition name="q-transition--fade">
-      <div v-if="alpha" v-show="!clear && show" class="alpha" :style="styleOpacityBeamer" />
-      <video v-else v-show="!clear && show" ref="player" :muted="muted" :src="fileUrl" class="video" />
-    </Transition>
+  <div>
+    <video-output v-bind="$attrs" />
   </div>
 </template>
 
 <script>
-import BaseOutput from '../output/BaseOutput.vue'
+import VideoOutput from './VideoOutput.vue'
 
 export default {
-  extends: BaseOutput,
-  props: {
-    muted: Boolean,
-    outputlivestream: Boolean
-  },
-  computed: {
-    fileUrl () {
-      return this.$store.getMediaUrl(this.settings.fileId)
-    },
-    player () {
-      return this.$refs.player
-    },
-    show () {
-      if (!this.outputlivestream) return true
-      return !this.settings.noLivestream
-    }
-  },
-  watch: {
-    'settings.play' (val) {
-      if (!this.player) return
-
-      val ? this.player.play() : this.player.pause()
-    },
-    'settings.time' (val) {
-      if (!this.player) return
-
-      this.player.currentTime = val
-    }
-  }
+  components: { VideoOutput }
 }
 </script>
-
-<style scoped>
-.video,
-.alpha {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-}
-
-.alpha {
-  background: #fff;
-}
-</style>

--- a/src/components/video/VideoOutputLivestream.vue
+++ b/src/components/video/VideoOutputLivestream.vue
@@ -1,13 +1,13 @@
 <template>
   <div>
-    <video-output-beamer v-bind="$attrs" outputlivestream muted />
+    <video-output v-bind="$attrs" outputlivestream muted />
   </div>
 </template>
 
 <script>
-import VideoOutputBeamer from './VideoOutputBeamer.vue'
+import VideoOutput from './VideoOutput.vue'
 
 export default {
-  components: { VideoOutputBeamer }
+  components: { VideoOutput }
 }
 </script>


### PR DESCRIPTION
Changes:
- beamer output naar los component (wat ook livestream had.)
  - VideoOutputBeamer.vue --> VideoOutput.vue
  - VideoOutputLiverstream.vue --> wijzig componentnaam
  - kopie VideoOutputLivestream.vue --> VideoOutputBeamer.vue
  - VideoOutputBeamer.vue --> verwijder output livestream en muted
- template in 1 div
- check this.player bij all watch
- clearTimeout toegevoegd.

-----------
de 1e lijkt de oplosing.
probleem leek te zitten in de preview output van de beamer; wanneer die uit kon geen vast loper meer reproduceren.
(in combinatie dit specifieke filmpje)
zie #351 