### PR TITLE
349 | add displaynr > electron, settings to screen + more display info

### DIFF
--- a/src-electron/electron-main.js
+++ b/src-electron/electron-main.js
@@ -10,6 +10,7 @@ let autoUpdaterDownloaded = false
 
 let mainWindow
 let pcoLiveWindow
+const displayWindowsNr = []
 
 const config = new Store()
 
@@ -22,6 +23,26 @@ ipcMain.handle('setConfig', (e, key, val) => {
 })
 ipcMain.handle('getAllDisplays', () => {
   return screen.getAllDisplays()
+})
+ipcMain.handle('showDisplaysNr', (e, show) => {
+  // remove existing display numbers
+  for (let i = 0; i < displayWindowsNr.length; i++) {
+    if (displayWindowsNr[i]) displayWindowsNr[i].close()
+  }
+  displayWindowsNr.length = 0
+
+  if (show) {
+    // show display numbers
+    const displays = screen.getAllDisplays()
+    for (let i = 0; i < displays.length; i++) {
+      displayWindowsNr.push(createWindow(`/showtext/${i + 1}`, displays[i], false, 150, 150, false))
+      displayWindowsNr[i].setAlwaysOnTop(true)
+      displayWindowsNr[i].setSkipTaskbar(true)
+    }
+    return true
+  }
+
+  return false
 })
 ipcMain.on('closeApp', () => {
   const autoupdateCheck = config.get('autoupdate')
@@ -156,7 +177,7 @@ app.on('window-all-closed', () => {
 
 app.on('before-quit', () => { app.quitting = true })
 
-function createWindow (url, display, fullscreen = false, width = 1344, height = 765) {
+function createWindow (url, display, fullscreen = false, width = 1344, height = 765, frame = true) {
   if (!display) {
     return // Display not found
   }
@@ -167,6 +188,7 @@ function createWindow (url, display, fullscreen = false, width = 1344, height = 
     icon: path.resolve(__dirname, 'icons/icon.png'), // tray icon
     width,
     height,
+    frame,
     x: x + 50,
     y: y + 50,
     useContentSize: true,

--- a/src-electron/electron-preload.js
+++ b/src-electron/electron-preload.js
@@ -23,6 +23,7 @@ contextBridge.exposeInMainWorld('electron', {
   getConfig: (key) => ipcRenderer.invoke('getConfig', key),
   setConfig: (key, val) => ipcRenderer.invoke('setConfig', key, val),
   getAllDisplays: () => ipcRenderer.invoke('getAllDisplays'),
+  showDisplaysNr: (show) => ipcRenderer.invoke('showDisplaysNr', show),
   onAutoUpdate: (status, percent, message) => ipcRenderer.on('autoUpdate', status, percent, message),
   onAppClose: (key) => ipcRenderer.on('appClose', key),
   closeApp: () => ipcRenderer.send('closeApp')

--- a/src/components/layout/AppSettingsDialog.vue
+++ b/src/components/layout/AppSettingsDialog.vue
@@ -3,7 +3,7 @@
     <q-card>
       <q-toolbar class="bg-secondary text-white">
         <q-toolbar-title>Instellingen</q-toolbar-title>
-        <q-btn v-close-popup flat round dense icon="close" />
+        <q-btn v-close-popup flat round dense icon="close" @click="hide" />
       </q-toolbar>
 
       <q-tabs v-model="tab" class="text-grey" active-color="primary" indicator-color="primary" align="left" narrow-indicator :breakpoint="0">
@@ -25,6 +25,7 @@
           <q-select v-model="displays.livestreamAlpha" :options="availableDisplayOptions" emit-value map-options clearable label="Livestream alpha channel" class="q-mb-sm" />
           <q-select v-model="displays.stage" :options="availableDisplayOptions" emit-value map-options clearable label="Stage monitor" class="q-mb-sm" />
           <q-select v-model="displays.pcolive" :options="availableDisplayOptions" emit-value map-options clearable label="PCO Live" />
+          <q-toggle v-model="showDisplayNr" checked-icon="check" color="primary" label="Monitor nummer weergeven" unchecked-icon="clear" @click="toggleShowDisplayNr" />
         </q-tab-panel>
 
         <q-tab-panel name="settings">
@@ -261,6 +262,7 @@ import { imageFiles, openPresentationPresetsSettings, removePresentationPresetsS
 export default {
   data () {
     return {
+      showDisplayNr: false,
       darkMode: false,
       availableDisplays: [],
       displays: {},
@@ -309,7 +311,7 @@ export default {
     availableDisplayOptions () {
       return this.availableDisplays.map((display, i) => ({
         value: i,
-        label: `Monitor ${i + 1}`
+        label: `Monitor ${i + 1} (${display.size?.width}x${display.size?.height}) ${display.internal ? 'intern' : display.label}`
       }))
     },
     algoliaIndexNames () {
@@ -336,7 +338,14 @@ export default {
       this.$refs.dialog.show()
     },
     hide () {
-      this.$refs.dialog.hide()
+      if (this.$q.platform.is.electron) {
+        if (this.showDisplayNr) {
+          // remove display nummer
+          this.showDisplayNr = false
+          this.toggleShowDisplayNr()
+        }
+      }
+      // this.$refs.dialog.hide() // --> v-close-popup
     },
     async load () {
       if (this.$q.platform.is.electron) {
@@ -436,6 +445,11 @@ export default {
     toggleDarkMode () {
       this.$q.dark.toggle()
       this.darkMode = this.$q.dark.isActive
+    },
+    async toggleShowDisplayNr () {
+      if (this.$q.platform.is.electron) {
+        this.showDisplayNr = await this.$electron.showDisplaysNr(this.showDisplayNr)
+      }
     }
   }
 }

--- a/src/components/output/ShowText.vue
+++ b/src/components/output/ShowText.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="bg-primary base">
+    {{ $route.params.nr }}
+  </div>
+</template>
+
+<script>
+// used for show display nr in electron
+export default {
+}
+</script>
+
+<style scoped lang="scss">
+.base {
+  user-select: none;
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  background-size: cover;
+  background-position: center;
+  color: white;
+  text-align: center;
+  font-size: 50vh;
+  line-height: 50vh;
+  padding-top: 25vh;
+}
+</style>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -1,6 +1,7 @@
 import App from 'components/App.vue'
 import Output from 'components/output/Output.vue'
 import OutputStage from 'components/output/OutputStage.vue'
+import ShowText from 'components/output/ShowText.vue'
 import Help from 'components/help/Help.vue'
 
 export default [
@@ -35,5 +36,9 @@ export default [
   {
     path: '/help',
     component: Help
+  },
+  {
+    path: '/showtext/:nr',
+    component: ShowText
   }
 ]


### PR DESCRIPTION
- [x] display nummer op scherm optie in electron via settings
- [x] extra display info in keuze lijst [resolutie + label of intern]
- [x] testen of ook werkt met meerdere schermen en voor de standaard output komt die fullscreen staat