### PR TITLE
225 gebruik v html extra controle tags

### DIFF
--- a/src/components/common/CleanText.js
+++ b/src/components/common/CleanText.js
@@ -24,3 +24,62 @@ export function CleanText (content) {
   if (text === '<div><br></div>' || text === '<div></div>') return ''
   return text
 }
+
+export function sanitizerHtml (content) {
+  if (!content) return content
+  // validHtml = 'div|br|p|b|i|u|sub|sup|small|ins|del|mark'
+  let text = content
+    .replace(/<\/?script(.*?)>/gi, '') //  verwijder alle <script ...> & </script> elementen
+    .replace(/<\/?span(.*?)>/gi, '') //    verwijder alle <span ...> & </span> elementen
+    .replace(/( style="(.*?);*"| class="(.*?)")>/gi, '>') // verwijder alle extra "style" & class elementen
+    .replace(/<(?!\/?(div|br|p|b|i|u|sub|sup|small|ins|del|mark)>)/gi, '&#60;') // vervang alle "<"...> welke niet validHtml hebben
+    .replace(/(?<!(<\/?(div|br|p|b|i|u|sub|sup|small|ins|del|mark)))>/gi, '&#62;') // vervang alle <...">" welke niet validHtml hebben
+  return text
+}
+
+export function sanitizerHtmlPresentation (presentation) {
+  if (!presentation) return presentation
+  // clean for xxs attack in v-html
+  switch (presentation.type) {
+    case 'song':
+      presentation.settings.title = sanitizerHtml(presentation.settings.title)
+      presentation.settings.collection = sanitizerHtml(presentation.settings.collection)
+      presentation.settings.number = sanitizerHtml(presentation.settings.number)
+      presentation.settings.text = sanitizerHtml(presentation.settings.text)
+      presentation.settings.translation = sanitizerHtml(presentation.settings.translation)
+      break
+    case 'caption':
+      presentation.settings.title = sanitizerHtml(presentation.settings.title)
+      presentation.settings.text = sanitizerHtml(presentation.settings.text)
+      break
+    case 'scripture':
+      presentation.settings.title = sanitizerHtml(presentation.settings.title)
+      presentation.settings.text = sanitizerHtml(presentation.settings.text)
+      presentation.settings.bible = sanitizerHtml(presentation.settings.bible)
+      presentation.settings.chapter = presentation.settings.chapter ? parseInt(presentation.settings.chapter) : presentation.settings.chapter
+      presentation.settings.verseFrom = presentation.settings.verseFrom ? parseInt(presentation.settings.verseFrom) : presentation.settings.verseFrom
+      presentation.settings.verseTo = presentation.settings.verseTo ? parseInt(presentation.settings.verseTo) : presentation.settings.verseTo
+      break
+    case 'image':
+    case 'video':
+        presentation.settings.title = sanitizerHtml(presentation.settings.title)
+        break
+    case 'countdown':
+      break
+    default:
+  }
+
+  return presentation
+}
+
+
+export function sanitizerHtmlService (service) {
+  if (!service) return service
+  // clean for xxs attack in v-html
+  service.presentations.forEach(presentation => {
+    // eslint-disable-next-line no-unused-vars
+    presentation = sanitizerHtmlPresentation(presentation)
+  })
+
+  return service
+}

--- a/src/components/presentation/PresentationSettingsDialog.vue
+++ b/src/components/presentation/PresentationSettingsDialog.vue
@@ -7,7 +7,7 @@
           <span v-if="presentation.id">{{ presentationType.name }} aanpassen</span>
           <span v-else>{{ presentationType.name }} toevoegen</span>
         </q-toolbar-title>
-        <q-btn v-close-popup flat round dense icon="close" />
+        <q-btn flat round dense icon="close" @click="close"/>
       </q-toolbar>
 
       <component :is="settingsComponent" v-if="settingsComponent" :presentation="presentation" />
@@ -25,6 +25,7 @@
 <script>
 import presentationTypes from '../presentation-types.js'
 import cloneDeep from 'lodash/cloneDeep'
+import { sanitizerHtmlPresentation } from '../common/CleanText.js'
 
 export default {
   emits: ['save'],
@@ -78,6 +79,7 @@ export default {
       this.show()
     },
     save () {
+      this.presentation = sanitizerHtmlPresentation(this.presentation)
       if (!this.presentation.id) {
         this.$store.addPresentation(this.presentation)
       }
@@ -86,7 +88,12 @@ export default {
       this.hide()
     },
     saveEmit () {
+      this.presentation = sanitizerHtmlPresentation(this.presentation)
       this.$emit('save')
+      this.hide()
+    },
+    close () {
+      this.presentation = sanitizerHtmlPresentation(this.presentation)
       this.hide()
     }
   }

--- a/src/components/song/database/BaseSongDatabaseCompare.vue
+++ b/src/components/song/database/BaseSongDatabaseCompare.vue
@@ -2,6 +2,7 @@
 import { HtmlDiff, CountDiff } from '../../common/HtmlDiff.js'
 import { splitSong } from '../SongControl.vue'
 import { getAlgoliaSearch, ApiKeyEdit, ConvertToAlgoliaRecord, AddToAlgoliaDatabase, algoliaIndexNames } from './algolia.js'
+import { sanitizerHtmlPresentation } from '../../common/CleanText.js';
 
 export default {
   data () {
@@ -298,6 +299,10 @@ export default {
       return resultSongDatabase
     },
     async addToDatabase () {
+      this.songs.forEach(song => {
+        // eslint-disable-next-line no-unused-vars
+        song = sanitizerHtmlPresentation(song)
+      })
       if (this.$store.searchBaseIsLocal) return this.addToLocalDatabase()
       return await this.addToAlgoliaDatabase()
     },

--- a/src/components/song/database/QuickSearchDatabase.vue
+++ b/src/components/song/database/QuickSearchDatabase.vue
@@ -160,6 +160,7 @@
 <script>
 import BaseSongDatabaseSearch from './BaseSongDatabaseSearch.vue'
 import presentationTypes from '../../presentation-types.js'
+import { sanitizerHtmlPresentation } from '../../common/CleanText.js'
 import cloneDeep from 'lodash/cloneDeep'
 
 export default {
@@ -199,10 +200,10 @@ export default {
       this.toSetlist(this.selected[0])
     },
     toSetlist (props) {
-      this.$store.addPresentation(this.propsToPresentation(props))
+      this.$store.addPresentation(sanitizerHtmlPresentation(this.propsToPresentation(props)))
     },
     toPreview (props) {
-      this.$store.preview(this.propsToPresentation(props))
+      this.$store.preview(sanitizerHtmlPresentation(this.propsToPresentation(props)))
     },
     propsToPresentation (props) {
       const type = presentationTypes.find(t => t.id === 'song')

--- a/src/components/song/database/SearchDatabaseDialog.vue
+++ b/src/components/song/database/SearchDatabaseDialog.vue
@@ -196,6 +196,7 @@ import BaseSongDatabaseSearch from './BaseSongDatabaseSearch.vue'
 import cloneDeep from 'lodash/cloneDeep'
 import presentationTypes from '../../presentation-types.js'
 import { ConvertToAlgoliaRecord, AddToAlgoliaDatabase, RemoveFromAlgoliaDatabase } from './algolia.js'
+import { sanitizerHtml, sanitizerHtmlPresentation} from '../../common/CleanText.js'
 
 export default {
   extends: BaseSongDatabaseSearch,
@@ -235,10 +236,10 @@ export default {
   },
   computed: {
     selectedLyrics () {
-      return this.selected[0]?.lyrics.replaceAll('\n', '<br>')
+      return sanitizerHtml(this.selected[0]?.lyrics.replaceAll('\n', '<br>'))
     },
     selectedLyricsTranslation () {
-      return this.selected[0]?.lyricstranslate.replaceAll('\n', '<br>')
+      return sanitizerHtml(this.selected[0]?.lyricstranslate.replaceAll('\n', '<br>'))
     },
     selectedTitle () {
       return this.selected[0]?.title || ''
@@ -284,11 +285,11 @@ export default {
       }
     },
     submitSong () {
-      this.$emit('update:title', this.selected[0]?.title)
-      this.$emit('update:collection', this.selected[0]?.collection ? this.selected[0]?.collection : '')
-      this.$emit('update:number', this.selected[0]?.number ? this.selected[0]?.number : '')
-      this.$emit('update:text', this.selected[0]?.lyrics)
-      this.$emit('update:translation', this.selected[0]?.lyricstranslate)
+      this.$emit('update:title', sanitizerHtml(this.selected[0]?.title))
+      this.$emit('update:collection', this.selected[0]?.collection ? sanitizerHtml(this.selected[0]?.collection) : '')
+      this.$emit('update:number', this.selected[0]?.number ? sanitizerHtml(this.selected[0]?.number) : '')
+      this.$emit('update:text', sanitizerHtml(this.selected[0]?.lyrics))
+      this.$emit('update:translation', sanitizerHtml(this.selected[0]?.lyricstranslate))
       if (this.userName) localStorage.setItem('database.userName', this.userName || '')
       this.hide()
     },
@@ -370,6 +371,7 @@ export default {
         this.editPresentation.settings.number = props.number || ''
         this.editPresentation.settings.text = props.lyrics || ''
         this.editPresentation.settings.translation = props.lyricstranslate || ''
+        this.editPresentation = sanitizerHtmlPresentation(this.editPresentation)
         // edit presentation
         this.$refs.presentationSettingsDialog.edit(this.editPresentation)
         // Return with emit save --> saveEditSong

--- a/src/components/song/database/SongDatabaseCompareDialog.vue
+++ b/src/components/song/database/SongDatabaseCompareDialog.vue
@@ -75,6 +75,7 @@
 
 <script>
 import BaseSongDatabaseCompare from './BaseSongDatabaseCompare.vue'
+import { sanitizerHtml } from '../../common/CleanText.js'
 
 export default {
   extends: BaseSongDatabaseCompare,
@@ -131,11 +132,11 @@ export default {
     },
     useDatabase () {
       if (this.presentation.settings) {
-        this.presentation.settings.title = this.selectedDatabase.title || ''
-        this.presentation.settings.collection = this.selectedDatabase.collection || ''
-        this.presentation.settings.number = this.selectedDatabase.number || ''
-        this.presentation.settings.text = this.selectedDatabase.lyrics || ''
-        this.presentation.settings.translation = this.selectedDatabase.lyricstranslate || ''
+        this.presentation.settings.title = sanitizerHtml(this.selectedDatabase.title) || ''
+        this.presentation.settings.collection = sanitizerHtml(this.selectedDatabase.collection) || ''
+        this.presentation.settings.number = sanitizerHtml(this.selectedDatabase.number) || ''
+        this.presentation.settings.text = sanitizerHtml(this.selectedDatabase.lyrics) || ''
+        this.presentation.settings.translation = sanitizerHtml(this.selectedDatabase.lyricstranslate) || ''
         this.hide()
       }
     },

--- a/src/components/song/database/SongItem.vue
+++ b/src/components/song/database/SongItem.vue
@@ -6,7 +6,7 @@
 
     <q-item-section>
       <q-item-label class="title row">
-        <div :class="todoTextClass" class="q-pr-md" v-html="title" />
+        <div :class="todoTextClass" class="q-pr-md" v-text="title" />
         <q-badge v-if="collectionNumber" :color="todoLabelColor">
           {{ collectionNumber }}
         </q-badge>

--- a/src/components/song/database/SongLyricsView.vue
+++ b/src/components/song/database/SongLyricsView.vue
@@ -2,10 +2,10 @@
   <div class="lyricsview">
     <div>
       <q-item-label :class="`text-h6 ${classDiff}`" :lines="1">
-        <div v-html="title" />
+        <div v-html="sanitizerHtml(title)" />
       </q-item-label>
       <q-item-label :class="`text-subtitle2 overflow-hidden${classDiff}`" :lines="1">
-        <div v-html="collectionNumber" />
+        <div v-html="sanitizerHtml(collectionNumber)" />
       </q-item-label>
     </div>
     <q-separator />
@@ -14,20 +14,21 @@
         <div class="text-primary">
           Tekst:
         </div>
-        <div :class="`lyrics${classDiff}`" :style="`height: ${lyricsHeight}vh;`" v-html="lyrics" />
+        <div :class="`lyrics${classDiff}`" :style="`height: ${lyricsHeight}vh;`" v-html="sanitizerHtml(lyrics)" />
       </div>
       <q-separator vertical class="q-mx-xs" />
       <div class="col-auto" style="max-width: 49%;">
         <div class="text-primary">
           Vertaling:
         </div>
-        <div :class="`lyrics${classDiff}`" :style="`height: ${lyricsHeight}vh;`" v-html="lyricsTranslation" />
+        <div :class="`lyrics${classDiff}`" :style="`height: ${lyricsHeight}vh;`" v-html="sanitizerHtml(lyricsTranslation)" />
       </div>
     </div>
   </div>
 </template>
 
 <script>
+import { sanitizerHtml } from '../../common/CleanText.js'
 export default {
   props: {
     title: String,
@@ -40,6 +41,11 @@ export default {
   computed: {
     classDiff () {
       return this.showDiff ? ' diff' : ''
+    }
+  },
+  methods: {
+    sanitizerHtml (contect) {
+      return sanitizerHtml(contect)
     }
   }
 }

--- a/src/stores/service.js
+++ b/src/stores/service.js
@@ -4,6 +4,7 @@ import { nanoid } from 'nanoid'
 import PACKAGE from '../../package.json'
 import presentationPresets from '../components/presentation-presets.js'
 import { versionUpdate } from './versionUpdate.js'
+import { sanitizerHtmlService } from '../components/common/CleanText.js'
 import { getDefaultURL } from '../components/presets-settings.js'
 
 let clearLastShortKey
@@ -36,21 +37,29 @@ export default defineStore('service', {
       this.serviceSaved = JSON.stringify(this.service)
     },
     loadService (data) {
-      this.service = cloneDeep(data)
+      // first update en check
+      let serviceOpen = cloneDeep(data)
+      if (serviceOpen.version !== PACKAGE.version) {
+        serviceOpen = versionUpdate(serviceOpen)
+        serviceOpen.version = PACKAGE.version
+      }
+      serviceOpen = sanitizerHtmlService(serviceOpen)
+      // add to store/render
+      this.service = cloneDeep(serviceOpen)
       this.previewPresentation = null
       this.livePresentation = null
-      if (this.service.version !== PACKAGE.version) {
-        this.service = versionUpdate(this.service)
-        this.service.version = PACKAGE.version
-      }
       this.serviceSaved = JSON.stringify(this.service)
     },
     addService (data) {
-      if (data.version !== PACKAGE.version) {
-        data = versionUpdate(data)
-        data.version = PACKAGE.version
+      // first update en check
+      let serviceAdd = cloneDeep(data)
+      if (serviceAdd.version !== PACKAGE.version) {
+        serviceAdd = versionUpdate(serviceAdd)
+        serviceAdd.version = PACKAGE.version
       }
-      data.presentations.forEach(presentation => {
+      serviceAdd = sanitizerHtmlService(serviceAdd)
+      // add to store/render
+      serviceAdd.presentations.forEach(presentation => {
         const existing = this.service.presentations.find(p => p.id === presentation.id)
         if (existing) presentation.id = nanoid()
         this.addPresentation(presentation)


### PR DESCRIPTION
blog uitleg: https://www.stackhawk.com/blog/vue-xss-guide-examples-and-prevention/
voorbeeld: `<p onmouseenter="alert('test xxs')"> Titel Vak 2 </p>`

_app draait lokaal en directe invoer is van de user zelf, geen koppeling server waar je anders dan via de algemene api-keys uit brouwser ook bij kan.; bij bewerken lijkt me niet nodig; pas bij opslaan presentation-item toepassen, zodat niet in setlist zit; daarnaast bij openen. Tijdens live dienst in basis niet toepassen ivm verwerkingstijd; vooraf voorkomen_

- [x] bij openen *.vez bestand op controleren en er uit halen.
- [x] opslaan/edit presentation in setlist
- [x] bij toevoegen lied uit (quick)database / song database
- [x] bij vergelijk en toepassen database
- [x] bij toevoegen aan database