### PR TITLE
fix pinia-shared-state - update tabs quick

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "lodash": "^4.17.21",
         "nanoid": "^5.0.9",
         "pinia": "^2.3.0",
-        "pinia-shared-state": "^0.5.1",
+        "pinia-shared-state": "J76F/pinia-shared-state",
         "quasar": "^2.17.6",
         "vue": "^3.5.13",
         "vue-router": "^4.5.0",
@@ -8588,8 +8588,7 @@
     },
     "node_modules/pinia-shared-state": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/pinia-shared-state/-/pinia-shared-state-0.5.1.tgz",
-      "integrity": "sha512-vPgKLrMSVhubQ1TPC+t9Vg2j2cabbJZDybxeG9BxVHrAFw35jb4IBvfFg9JGv+ULKxIdRvvg4u4I0zan2Juqqg==",
+      "resolved": "git+ssh://git@github.com/J76F/pinia-shared-state.git#289a92f30673a6c2f945a0b0f0f22e0773cc5e6b",
       "license": "MIT",
       "dependencies": {
         "broadcast-channel": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lodash": "^4.17.21",
     "nanoid": "^5.0.9",
     "pinia": "^2.3.0",
-    "pinia-shared-state": "^0.5.1",
+    "pinia-shared-state": "J76F/pinia-shared-state",
     "quasar": "^2.17.6",
     "vue": "^3.5.13",
     "vue-router": "^4.5.0",


### PR DESCRIPTION
fout in npm pinia-shared-state 0.5.1
--> hierdoor geen update bij snelle (millisec) updates door gebruik date.now ipv newstate.timestamp.
--> tijdelijk opgeloast in J76F/pinia-shared-state tot PR in npm zit.